### PR TITLE
add intro

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ Thumbs.db
 refs/**/target/
 refs/**/*.rs.bk
 refs/**/Cargo.lock
+build

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,51 @@
+TARGET=x86_64-unknown-none
+NAME=$(shell echo "${PWD##*/}")
+ROOT=./generated
+RUSTFLAGS=\
+		  -C link-args=-e \
+		  -C link-args=entry \
+		  -C link-args=-z \
+		  -C link-args=execstack
+CARGO=RUSTFLAGS='$(RUSTFLAGS)' cargo
+BIN_PATH_DEBUG=$(shell cargo metadata --format-version 1 | jq -r .target_directory)/debug/$(NAME)
+APP_BUILD_ARG=-v --target $(TARGET) --release
+
+.PHONY : build
+build :
+	rustup target add $(TARGET)
+	$(CARGO) build $(APP_BUILD_ARG)
+
+.PHONY : test
+test :
+	cargo build
+	cargo test
+
+.PHONY : clippy
+clippy :
+	rustup target add $(TARGET)
+	cargo clippy --all-features --target=$(TARGET) -- -D warnings
+	cargo clippy --all-features -- -D warnings
+
+.PHONY : objdump
+objdump :
+	cargo install cargo-binutils
+	rustup component add llvm-tools-preview
+	$(CARGO) objdump -- -d
+
+.PHONY : nm
+nm :
+	cargo install cargo-binutils
+	rustup component add llvm-tools-preview
+	$(CARGO) nm
+
+.PHONY : readelf
+readelf : build
+	readelf -l $(BIN_PATH_DEBUG)
+
+.PHONY : hexdump
+hexdump : build
+	hexdump -C $(BIN_PATH_DEBUG)
+
+.PHONY : run
+run :
+	make -C ../../ run

--- a/run_on_wasabi.sh
+++ b/run_on_wasabi.sh
@@ -1,0 +1,43 @@
+#!/bin/bash -xe
+
+HOME_PATH=$PWD
+TARGET_PATH=$PWD"/build"
+OS_PATH=$TARGET_PATH"/wasabi"
+APP_NAME="saba"
+MAKEFILE_PATH=$HOME_PATH"/Makefile"
+
+# execute `mkdir build/` if it doesn't exist
+if [ -d $TARGET_PATH ]
+then
+  echo $TARGET_PATH" exists"
+else
+  echo $TARGET_PATH" doesn't exist"
+  mkdir $TARGET_PATH
+fi
+
+# install Wasabi OS (https://github.com/hikalium/wasabi)
+# You should manually remove wasabi/ if it's conflict via `rm -rf $OS_PATH`
+if [ -d $OS_PATH ]
+then
+  echo $OS_PATH" exists"
+  echo "pulling new changes..."
+  cd $OS_PATH
+  git pull origin for_saba
+else
+  echo $OS_PATH" doesn't exist"
+  echo "cloning wasabi project..."
+  cd $TARGET_PATH
+  git clone --branch for_saba git@github.com:hikalium/wasabi.git
+fi
+
+# go back to the application top directory
+cd $HOME_PATH
+
+# download Makefile if it doesn't exist
+if [ ! -f $MAKEFILE_PATH ]; then
+  echo "downloading Makefile..."
+  wget https://raw.githubusercontent.com/hikalium/wasabi/main/external_app_template/Makefile
+fi
+
+make build
+$OS_PATH/scripts/run_with_app.sh ./target/x86_64-unknown-none/release/$APP_NAME

--- a/saba/Cargo.toml
+++ b/saba/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "saba"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+noli = { git = "https://github.com/hikalium/wasabi.git", branch = "for_saba" }

--- a/saba/src/main.rs
+++ b/saba/src/main.rs
@@ -1,0 +1,12 @@
+#![no_std]
+#![cfg_attr(not(target_os = "linux"), no_main)]
+
+use noli::prelude::*;
+
+fn main() {
+    Api::write_string("Hello World\n");
+    println!("Hello from println!");
+    Api::exit(42);
+}
+
+entry_point!(main);


### PR DESCRIPTION
This pull request introduces a new Rust project setup for the `saba` application, including a `Makefile`, a shell script for running the application on Wasabi OS, and the initial Rust code and dependencies. The most important changes are the addition of the `Makefile`, the `run_on_wasabi.sh` script, and the initial Rust project files.

Project setup and build configuration:

* Added a `Makefile` to define various build and test commands, including targets for building, testing, running clippy, and generating binary dumps.
* Added `run_on_wasabi.sh` script to automate the setup and execution of the `saba` application on Wasabi OS. This script handles directory creation, cloning the Wasabi OS repository, and running the application.

Rust project initialization:

* Created `Cargo.toml` for the `saba` project, specifying the project name, version, edition, and dependencies.
* Added the initial Rust source file `main.rs` for the `saba` application, which includes a simple "Hello World" program using the `noli` library from Wasabi OS.