### PR TITLE
add get host

### DIFF
--- a/saba_core/src/url.rs
+++ b/saba_core/src/url.rs
@@ -1,4 +1,5 @@
 use alloc::string::String;
+use alloc::vec::Vec;
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct Url {
@@ -32,14 +33,27 @@ impl Url {
         }
     }
     pub fn parse(&mut self) -> Result<Self, String> {
-      if !self.is_http() {
-        return Err("Only HTTP scheme is supported.".to_string());
-      }
+        if !self.is_http() {
+            return Err("Only HTTP scheme is supported.".to_string());
+        }
     }
     fn is_http(&mut self) -> bool {
-      if self.url.contains("http://") {
-        return true;
-      }
-      false
+        if self.url.contains("http://") {
+            return true;
+        }
+        false
+    }
+    fn extracted_host(&self) -> String {
+        let url_parts: Vec<&str> = self
+            .url
+            .trim_start_matches("http://")
+            .splitn(2, '/')
+            .collect();
+
+        if let Some(index) = url_parts[0].find(':') {
+            return url_parts[0][..index].to_string();
+        } else {
+            url_parts[0].to_string()
+        }
     }
 }


### PR DESCRIPTION
This pull request includes changes to the `saba_core/src/url.rs` file to enhance URL parsing functionality. The most important changes are the addition of a new method to extract the host from a URL and the import of a new module.

Enhancements to URL parsing:

* [`saba_core/src/url.rs`](diffhunk://#diff-c3b6bdc67d01e7162750dfa65a6871d37a02d7e7a44a0d9348caf396d3f1b850R2): Added `alloc::vec::Vec` to the list of imports to support vector operations.
* [`saba_core/src/url.rs`](diffhunk://#diff-c3b6bdc67d01e7162750dfa65a6871d37a02d7e7a44a0d9348caf396d3f1b850R46-R58): Introduced a new method `extracted_host` in the `Url` struct to extract the host part of a URL. This method trims the "http://" prefix and splits the URL to isolate the host.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new method to extract the host from a URL, enhancing URL handling capabilities.

- **Bug Fixes**
	- Improved readability of existing methods for better maintenance and understanding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->