### PR TITLE
add path

### DIFF
--- a/saba_core/src/url.rs
+++ b/saba_core/src/url.rs
@@ -69,4 +69,17 @@ impl Url {
             "80".to_string()
         }
     }
+    fn extract_path(&self) -> String {
+        let url_parts: Vec<&str> = self
+            .url
+            .trim_start_matches("http://")
+            .splitn(2, '/')
+            .collect();
+
+        if url_parts.len() > 2 {
+            return "".to_string();
+        }
+        let path_and_searchpart: Vec<&str> = url_parts[1].splitn(2, '?').collect();
+        path_and_searchpart[0].to_string()
+    }
 }


### PR DESCRIPTION
This pull request introduces a new method to the `Url` implementation in the `saba_core` crate. The most important change is the addition of a method to extract the path from a URL.

New method added:

* [`saba_core/src/url.rs`](diffhunk://#diff-c3b6bdc67d01e7162750dfa65a6871d37a02d7e7a44a0d9348caf396d3f1b850R72-R84): Added the `extract_path` method to the `Url` implementation. This method splits the URL to extract and return the path component, excluding the search part.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new method to extract the path component from URLs, enhancing URL handling capabilities. 

- **Bug Fixes**
	- Improved path extraction logic to ensure accurate results when splitting URL components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->