### PR TITLE
add searchpart

### DIFF
--- a/saba_core/src/url.rs
+++ b/saba_core/src/url.rs
@@ -82,4 +82,21 @@ impl Url {
         let path_and_searchpart: Vec<&str> = url_parts[1].splitn(2, '?').collect();
         path_and_searchpart[0].to_string()
     }
+    fn extract_searchpart(&self) -> String {
+        let url_parts: Vec<&str> = self
+            .url
+            .trim_start_matches("http://")
+            .splitn(2, '/')
+            .collect();
+
+        if url_parts.len() > 2 {
+            return "".to_string();
+        }
+        let path_and_searchpart: Vec<&str> = url_parts[1].splitn(2, '?').collect();
+        if path_and_searchpart.len() < 2 {
+            "".to_string()
+        } else {
+            path_and_searchpart[1].to_string()
+        }
+    }
 }


### PR DESCRIPTION
This pull request introduces a new method to the `Url` implementation in the `saba_core` library to extract the search part of a URL. This enhancement aims to improve URL parsing capabilities by providing a dedicated function for extracting query parameters.

Enhancements to URL parsing:

* [`saba_core/src/url.rs`](diffhunk://#diff-c3b6bdc67d01e7162750dfa65a6871d37a02d7e7a44a0d9348caf396d3f1b850R85-R101): Added a new method `extract_searchpart` to the `Url` implementation to extract and return the search part (query parameters) of a URL. This method handles URLs without query parameters by returning an empty string.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new method for extracting the search part of a URL, enhancing URL processing capabilities. 

- **Bug Fixes**
	- Ensured that the method handles various URL formats correctly, returning appropriate results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->