### PR TITLE
add host to ip

### DIFF
--- a/net/wasabi/src/http.rs
+++ b/net/wasabi/src/http.rs
@@ -1,4 +1,5 @@
-extern crate alloc;
+use crate::alloc::string::ToString;
+use alloc::format;
 use noli::net::lookup_host;
 use saba_core::error::Error;
 use saba_core::http::HttpResponse;

--- a/net/wasabi/src/http.rs
+++ b/net/wasabi/src/http.rs
@@ -1,4 +1,7 @@
 extern crate alloc;
+use noli::net::lookup_host;
+use saba_core::error::Error;
+use saba_core::http::HttpResponse;
 
 #[derive(Default)]
 pub struct HttpClient {}
@@ -6,5 +9,19 @@ pub struct HttpClient {}
 impl HttpClient {
     pub fn new() -> Self {
         Self {}
+    }
+    pub fn get(&self, host: String, port: u16, path: String) -> Result<HttpResponse, Error> {
+        let ips = match lookup_host(&host) {
+            Ok(ips) => ips,
+            Err(e) => {
+                return Err(Error::Network(format!(
+                    "Failed to find IP Addresses: {:#?} ",
+                    e
+                )))
+            }
+        };
+        if ips.len() < 1 {
+            return Err(Error::Network("No IP Addresses found for".to_string()));
+        }
     }
 }

--- a/net/wasabi/src/http.rs
+++ b/net/wasabi/src/http.rs
@@ -1,5 +1,9 @@
-use crate::alloc::string::ToString;
-use alloc::format;
+extern crate alloc;
+
+use alloc::string::String;
+use alloc::vec::Vec;
+use core::fmt::Write;
+
 use noli::net::lookup_host;
 use saba_core::error::Error;
 use saba_core::http::HttpResponse;
@@ -11,18 +15,30 @@ impl HttpClient {
     pub fn new() -> Self {
         Self {}
     }
-    pub fn get(&self, host: String, port: u16, path: String) -> Result<HttpResponse, Error> {
+
+    pub fn get(&self, host: String, _port: u16, _path: String) -> Result<HttpResponse, Error> {
         let ips = match lookup_host(&host) {
             Ok(ips) => ips,
             Err(e) => {
-                return Err(Error::Network(format!(
-                    "Failed to find IP Addresses: {:#?} ",
-                    e
-                )))
+                // `format!`マクロの代わりに、`String`と`write!`マクロを使用します
+                let mut s = String::from("Failed to find IP Addresses: ");
+                write!(&mut s, "{:#?}", e)
+                    .map_err(|_| Error::Other(String::from("Formatting Error")))?;
+                return Err(Error::Network(s));
             }
         };
-        if ips.len() < 1 {
-            return Err(Error::Network("No IP Addresses found for".to_string()));
+
+        if ips.is_empty() {
+            return Err(Error::Network(String::from("No IP Addresses found for")));
         }
+
+        // 仮のHTTPレスポンスを返します
+        Ok(HttpResponse::new(
+            String::from("HTTP/1.1"),
+            200,
+            String::from("OK"),
+            Vec::new(),
+            String::from(""),
+        ))
     }
 }


### PR DESCRIPTION
This pull request introduces new functionality to the `HttpClient` in the `net/wasabi/src/http.rs` file by adding a `get` method. The most important changes include importing necessary modules and defining the `get` method to perform HTTP GET requests.

### Enhancements to `HttpClient`:

* [`net/wasabi/src/http.rs`](diffhunk://#diff-b237807e2a8430b80fcb844fa2e4febdd62886a4de77bc82d85ff84dd76f4bf2R2-R4): Added imports for `lookup_host` from `noli::net`, and `Error` and `HttpResponse` from `saba_core` to support the new `get` method.
* [`net/wasabi/src/http.rs`](diffhunk://#diff-b237807e2a8430b80fcb844fa2e4febdd62886a4de77bc82d85ff84dd76f4bf2R13-R26): Implemented the `get` method in `HttpClient` to resolve hostnames to IP addresses and handle potential errors, preparing for HTTP GET requests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new method in the HTTP client for improved network resolution and error handling.
- **Bug Fixes**
	- Enhanced error handling for scenarios where host resolution fails or no IP addresses are found.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->