### PR TITLE
add port number

### DIFF
--- a/net/wasabi/src/http.rs
+++ b/net/wasabi/src/http.rs
@@ -5,6 +5,8 @@ use alloc::vec::Vec;
 use core::fmt::Write;
 
 use noli::net::lookup_host;
+use noli::net::SocketAddr;
+use noli::println;
 use saba_core::error::Error;
 use saba_core::http::HttpResponse;
 
@@ -16,7 +18,7 @@ impl HttpClient {
         Self {}
     }
 
-    pub fn get(&self, host: String, _port: u16, _path: String) -> Result<HttpResponse, Error> {
+    pub fn get(&self, host: String, port: u16, _path: String) -> Result<HttpResponse, Error> {
         let ips = match lookup_host(&host) {
             Ok(ips) => ips,
             Err(e) => {
@@ -32,6 +34,8 @@ impl HttpClient {
             return Err(Error::Network(String::from("No IP Addresses found for")));
         }
 
+        let socket_addr: SocketAddr = (ips[0], port).into();
+        println!("socket_addr: {:?}", socket_addr);
         // 仮のHTTPレスポンスを返します
         Ok(HttpResponse::new(
             String::from("HTTP/1.1"),


### PR DESCRIPTION
This pull request includes several changes to the `net/wasabi/src/http.rs` file to enhance the functionality of the `HttpClient` class. The most important changes include adding necessary imports, modifying the `get` method to use the port parameter, and adding code to print the socket address.

Enhancements to `HttpClient`:

* [`net/wasabi/src/http.rs`](diffhunk://#diff-b237807e2a8430b80fcb844fa2e4febdd62886a4de77bc82d85ff84dd76f4bf2R8-R9): Added imports for `SocketAddr` and `println` to support the new functionalities.
* [`net/wasabi/src/http.rs`](diffhunk://#diff-b237807e2a8430b80fcb844fa2e4febdd62886a4de77bc82d85ff84dd76f4bf2L19-R21): Modified the `get` method in the `HttpClient` class to use the `port` parameter.
* [`net/wasabi/src/http.rs`](diffhunk://#diff-b237807e2a8430b80fcb844fa2e4febdd62886a4de77bc82d85ff84dd76f4bf2R37-R38): Added code to create a `SocketAddr` from the first IP address and port, and print it for debugging purposes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the `get` method to require a port parameter for improved socket address creation.
	- Added logging for the constructed socket address to assist with debugging.

- **Bug Fixes**
	- Maintained robust error handling for IP address resolution issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->