### PR TITLE
add stream

### DIFF
--- a/net/wasabi/src/http.rs
+++ b/net/wasabi/src/http.rs
@@ -6,6 +6,7 @@ use core::fmt::Write;
 
 use noli::net::lookup_host;
 use noli::net::SocketAddr;
+use noli::net::TcpStream;
 use noli::println;
 use saba_core::error::Error;
 use saba_core::http::HttpResponse;
@@ -36,6 +37,16 @@ impl HttpClient {
 
         let socket_addr: SocketAddr = (ips[0], port).into();
         println!("socket_addr: {:?}", socket_addr);
+
+        let _stream = match TcpStream::connect(socket_addr) {
+            Ok(stream) => stream,
+            Err(_e) => {
+                return Err(Error::Network(String::from(
+                    "Failed to connect to TCP stream",
+                )))
+            }
+        };
+
         // 仮のHTTPレスポンスを返します
         Ok(HttpResponse::new(
             String::from("HTTP/1.1"),


### PR DESCRIPTION
This pull request includes changes to the `net/wasabi/src/http.rs` file to enhance the functionality of the HTTP client by adding support for TCP stream connections.

Enhancements to HTTP client:

* [`net/wasabi/src/http.rs`](diffhunk://#diff-b237807e2a8430b80fcb844fa2e4febdd62886a4de77bc82d85ff84dd76f4bf2R9): Added `use noli::net::TcpStream;` to import the `TcpStream` module for establishing TCP connections.
* [`net/wasabi/src/http.rs`](diffhunk://#diff-b237807e2a8430b80fcb844fa2e4febdd62886a4de77bc82d85ff84dd76f4bf2R40-R49): Modified the `impl HttpClient` block to include logic for connecting to a TCP stream and handling connection errors. This ensures that the client attempts to establish a TCP connection to the specified socket address and returns a network error if the connection fails.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced TCP connection handling in the HTTP client for improved network reliability.
  
- **Bug Fixes**
	- Improved error handling for IP address resolution and TCP connection failures, providing clearer error messages to users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->