### PR TITLE
add send request

### DIFF
--- a/net/wasabi/src/http.rs
+++ b/net/wasabi/src/http.rs
@@ -38,7 +38,7 @@ impl HttpClient {
         let socket_addr: SocketAddr = (ips[0], port).into();
         println!("socket_addr: {:?}", socket_addr);
 
-        let _stream = match TcpStream::connect(socket_addr) {
+        let mut stream = match TcpStream::connect(socket_addr) {
             Ok(stream) => stream,
             Err(_e) => {
                 return Err(Error::Network(String::from(
@@ -56,13 +56,22 @@ impl HttpClient {
         request.push_str("Accept: text/html\r\n");
         request.push_str("Connection: close\r\n");
         request.push_str("\r\n");
-        // 仮のHTTPレスポンスを返します
+
+        let _bytes_written = match stream.write(request.as_bytes()) {
+            Ok(bytes) => bytes,
+            Err(_e) => {
+                return Err(Error::Network(String::from("Failed to write to stream")));
+            }
+        };
+
+        // TODO: レスポンスの読み取りと解析を実装
+        // 一時的な実装として、基本的なレスポンスを返す
         Ok(HttpResponse::new(
             String::from("HTTP/1.1"),
             200,
             String::from("OK"),
             Vec::new(),
-            String::from(""),
+            String::new(),
         ))
     }
 }


### PR DESCRIPTION
This pull request includes changes to the `HttpClient` implementation in the `net/wasabi/src/http.rs` file. The primary goal is to handle the TCP stream more effectively and prepare for future enhancements in response handling.

Improvements to TCP stream handling:

* Changed the `stream` variable to be mutable to allow for future write operations.
* Added code to handle writing the HTTP request to the stream, with error handling for failed write attempts.

Preparation for future enhancements:

* Added a TODO comment to indicate the need for implementing response reading and parsing, with a temporary basic response returned for now.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling for IP address resolution and TCP stream writing.
	- Enhanced clarity in network operation responses.

- **Documentation**
	- Updated comments for better understanding of HTTP response handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->