### PR TITLE
add receive response

### DIFF
--- a/net/wasabi/src/http.rs
+++ b/net/wasabi/src/http.rs
@@ -64,6 +64,23 @@ impl HttpClient {
             }
         };
 
+        let mut recieved = Vec::new();
+        loop {
+            let mut buffer = [0u8; 1024];
+            let bytes_read = match stream.read(&mut buffer) {
+                Ok(bytes) => bytes,
+                Err(_e) => {
+                    return Err(Error::Network(String::from("Failed to read from stream")));
+                }
+            };
+
+            if bytes_read == 0 {
+                break;
+            }
+
+            recieved.extend_from_slice(&buffer[..bytes_read]);
+        }
+
         // TODO: レスポンスの読み取りと解析を実装
         // 一時的な実装として、基本的なレスポンスを返す
         Ok(HttpResponse::new(


### PR DESCRIPTION
This pull request includes a significant update to the `HttpClient` implementation in `net/wasabi/src/http.rs`. The main change involves adding a loop to read data from a stream and handle potential read errors.

### Improvements to `HttpClient` data handling:

* Added a loop to read data from the stream into a buffer and handle errors if the read operation fails. The buffer contents are then extended into a `Vec` to accumulate the received data. (`net/wasabi/src/http.rs`, [net/wasabi/src/http.rsR67-R83](diffhunk://#diff-b237807e2a8430b80fcb844fa2e4febdd62886a4de77bc82d85ff84dd76f4bf2R67-R83))

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced HTTP client functionality to continuously read and accumulate response data from TCP streams.
  
- **Bug Fixes**
	- Improved error handling for potential read failures during data retrieval.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->