### PR TITLE
add other response test

### DIFF
--- a/saba_core/src/http.rs
+++ b/saba_core/src/http.rs
@@ -115,4 +115,32 @@ mod tests {
         assert_eq!(response.reason(), "OK");
         assert_eq!(response.header_value("Date"), Ok("xx xx xx".to_string()));
     }
+
+    #[test]
+    fn test_two_headers_with_white_space() {
+        let raw = "HTTP/1.1 200 OK\nDate:xx xx xx\nContent-Length: 42\n\n".to_string();
+        let response = HttpResponse::new(raw).expect("failed to parse http response");
+        assert_eq!(response.version(), "HTTP/1.1");
+        assert_eq!(response.status_code(), 200);
+        assert_eq!(response.reason(), "OK");
+        assert_eq!(response.header_value("Date"), Ok("xx xx xx".to_string()));
+        assert_eq!(
+            response.header_value("Content-Length"),
+            Ok("42".to_string())
+        );
+    }
+    #[test]
+    fn test_body() {
+        let raw = "HTTP/1.1 200 OK\nDate:xx xx xx\n\nbody message".to_string();
+        let response = HttpResponse::new(raw).expect("failed to parse http response");
+        assert_eq!(response.version(), "HTTP/1.1");
+        assert_eq!(response.status_code(), 200);
+        assert_eq!(response.reason(), "OK");
+        assert_eq!(response.body(), "body message".to_string());
+    }
+    #[test]
+    fn test_invalid() {
+        let raw = "HTTP/1.1 200 OK".to_string();
+        assert!(HttpResponse::new(raw).is_err());
+    }
 }


### PR DESCRIPTION
This pull request adds new test cases to the `saba_core/src/http.rs` file to improve the test coverage for the `HttpResponse` struct. The most important changes include adding tests for headers with white spaces, response body parsing, and handling invalid HTTP responses.

New test cases added:

* [`saba_core/src/http.rs`](diffhunk://#diff-a5a0bd7d3e3ab16ccd816702197dc4ded98f7da4fc1ac550bc9174a51e1f0dfdR118-R145): Added `test_two_headers_with_white_space` to verify parsing of headers containing white spaces.
* [`saba_core/src/http.rs`](diffhunk://#diff-a5a0bd7d3e3ab16ccd816702197dc4ded98f7da4fc1ac550bc9174a51e1f0dfdR118-R145): Added `test_body` to verify the correct parsing of the response body.
* [`saba_core/src/http.rs`](diffhunk://#diff-a5a0bd7d3e3ab16ccd816702197dc4ded98f7da4fc1ac550bc9174a51e1f0dfdR118-R145): Added `test_invalid` to check the handling of invalid HTTP responses.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
	- Introduced new test cases for HTTP response parsing, enhancing coverage for header handling, body retrieval, and error conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->