### PR TITLE
add http client from main

### DIFF
--- a/run_on_wasabi.sh
+++ b/run_on_wasabi.sh
@@ -27,7 +27,7 @@ else
   echo $OS_PATH" doesn't exist"
   echo "cloning wasabi project..."
   cd $TARGET_PATH
-  git clone --branch for_saba git@github.com:hikalium/wasabi.git
+  git clone --branch for_saba https://github.com/hikalium/wasabi.git
 fi
 
 # go back to the application top directory

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,7 @@ use crate::alloc::string::ToString;
 use net_wasabi::http::HttpClient;
 use noli::prelude::*;
 
-fn main() -> u64 {
+fn main() {
     let client = HttpClient::new();
     match client.get("example.com".to_string(), 80, "/".to_string()) {
         Ok(res) => {
@@ -16,7 +16,6 @@ fn main() -> u64 {
             println!("error: {:?}", e);
         }
     }
-    0
 }
 
 entry_point!(main);

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,12 +1,22 @@
 #![no_std]
 #![cfg_attr(not(target_os = "linux"), no_main)]
 
+extern crate alloc;
+use crate::alloc::string::ToString;
+use net_wasabi::http::HttpClient;
 use noli::prelude::*;
 
-fn main() {
-    Api::write_string("Hello World\n");
-    println!("Hello from println!");
-    Api::exit(42);
+fn main() -> u64 {
+    let client = HttpClient::new();
+    match client.get("example.com".to_string(), 80, "/".to_string()) {
+        Ok(res) => {
+            println!("response: {:?}", res);
+        }
+        Err(e) => {
+            println!("error: {:?}", e);
+        }
+    }
+    0
 }
 
 entry_point!(main);


### PR DESCRIPTION
This pull request includes changes to the `src/main.rs` file to add HTTP client functionality and modify the `main` function. The most important changes are:

### HTTP Client Integration:
* Added `extern crate alloc` and `use crate::alloc::string::ToString` to enable dynamic memory allocation and string manipulation.
* Imported `HttpClient` from the `net_wasabi::http` module to facilitate HTTP requests.

### Main Function Modifications:
* Changed the return type of the `main` function to `u64` and updated its implementation to create an `HttpClient` instance and perform a GET request to "example.com".
* Removed the previous calls to `Api::write_string`, `println!`, and `Api::exit` to replace them with the new HTTP client logic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced the main functionality to perform an HTTP GET request to "example.com" and handle responses effectively.
	- Updated the repository cloning method in the script to use HTTPS for improved accessibility.
- **Bug Fixes**
	- Improved error handling for HTTP requests, providing clearer feedback on success or failure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->