### PR TITLE
add html tokenizer

### DIFF
--- a/saba_core/src/renderer/html/attribute.rs
+++ b/saba_core/src/renderer/html/attribute.rs
@@ -1,0 +1,26 @@
+use alloc::string::String;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Attribute {
+    pub name: String,
+    pub value: String,
+}
+
+impl Attribute {
+    pub fn new(name: String, value: String) -> Self {
+        Self { name, value }
+    }
+    pub fn add_char(&mut self, c: char, is_name: bool) {
+        if is_name {
+            self.name.push(c);
+        } else {
+            self.value.push(c);
+        }
+    }
+    pub fn name(&self) -> String {
+        self.name.clone()
+    }
+    pub fn value(&self) -> String {
+        self.value.clone()
+    }
+}

--- a/saba_core/src/renderer/html/mod.rs
+++ b/saba_core/src/renderer/html/mod.rs
@@ -1,1 +1,2 @@
+pub mod attribute;
 pub mod token;

--- a/saba_core/src/renderer/html/token.rs
+++ b/saba_core/src/renderer/html/token.rs
@@ -1,2 +1,87 @@
-// ファイルの内容をここから開始
-// 余分な空行を削除
+use crate::renderer::html::attribute::Attribute;
+use alloc::string::String;
+use alloc::vec::Vec;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HtmlTokenizer {
+    state: State,
+    pos: usize,
+    reconsume: bool,
+    latest_token: Option<HtmlToken>,
+    input: Vec<char>,
+    buf: String,
+}
+
+impl HtmlTokenizer {
+    pub fn new(input: Vec<char>) -> Self {
+        Self {
+            state: State::Data,
+            pos: 0,
+            reconsume: false,
+            latest_token: None,
+            input,
+            buf: String::new(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum HtmlToken {
+    StartTag {
+        tag: String,
+        self_closing: bool,
+        attributes: Vec<Attribute>,
+    },
+    EndTag {
+        tag: String,
+    },
+    Character(char),
+    EOF,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum State {
+    Data,
+    TagOpen,
+    EndTagOpen,
+    TagName,
+    BeforeAttributeName,
+    AttributeName,
+    AfterAttributeName,
+    BeforeAttributeValue,
+    AttributeValueDoubleQuoted,
+    AttributeValueSingleQuoted,
+    AttributeValueUnQuoted,
+    AfterAttributeValueQuoted,
+    SelfClosingStartTag,
+    ScriptData,
+    ScriptDataLessThanSign,
+    ScriptDataEndTagOpen,
+    ScriptDataEndTagName,
+    TemporaryBuffer,
+}
+
+// match self.state {
+//     State::Data => {}
+//     State::TagOpen => {}
+//     State::EndTagOpen => {}
+//     State::TagName => {}
+//     State::BeforeAttributeName => {}
+//     State::AttributeName => {}
+//     State::AfterAttributeName => {}
+// }
+
+impl Iterator for HtmlTokenizer {
+    type Item = HtmlToken;
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.pos >= self.input.len() {
+            return None;
+        }
+        loop {
+            if self.state == State::Data {
+                // Data状態の処理
+            }
+            // 他の状態の処理
+        }
+    }
+}


### PR DESCRIPTION
This pull request introduces significant changes to the HTML renderer component in the `saba_core` module. The most important changes include the addition of a new `Attribute` struct, modifications to the HTML tokenizer, and the inclusion of a new module for attributes.

### Additions to HTML Renderer:

* [`saba_core/src/renderer/html/attribute.rs`](diffhunk://#diff-b1ce55070fd122aa67786153a56132be3327f355c8bcff8599ed905b4a0505b7R1-R26): Added a new `Attribute` struct with methods for creating and manipulating HTML attributes.
* [`saba_core/src/renderer/html/mod.rs`](diffhunk://#diff-ee9d5cace28b42f5c45ddc6df2217cee682a79c52dd3c4b08fed8d5432fc43e7R1): Included the newly created `attribute` module.

### Modifications to HTML Tokenizer:

* `saba_core/src/renderer/html/token.rs`: 
  * Introduced `HtmlTokenizer` struct and implemented the `Iterator` trait for it.
  * Added `HtmlToken` and `State` enums to represent different states and tokens in the HTML parsing process.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new `Attribute` structure for managing HTML attributes.
	- Added a `HtmlTokenizer` for processing HTML input into tokens.
- **Enhancements**
	- New methods for manipulating and accessing HTML attributes.
	- Defined enums for token types and tokenizer states to improve structure and functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->