### PR TITLE
add AttributeValueSingleQuoted

### DIFF
--- a/saba_core/src/renderer/html/token.rs
+++ b/saba_core/src/renderer/html/token.rs
@@ -295,6 +295,30 @@ impl Iterator for HtmlTokenizer {
                   }
                   self.append_attribute_value(c, /*is_name*/ false);
                 }
+                State::AttributeValueSingleQuoted => {
+                  if c == '\'' {
+                    self.state = State::AfterAttributeValueQuoted;
+                    continue;
+                  }
+                  if self.is_eof() {
+                    return Some(HtmlToken::Eof);
+                  }
+                  self.append_attribute_value(c, /*is_name*/ false);
+                }
+                State::AttributeValueUnQuoted => {
+                  if c == ' ' {
+                    self.state = State::BeforeAttributeName;
+                    continue;
+                  }
+                  if c == '/' {
+                    self.state = State::Data;
+                    return self.take_latest_token();
+                  }
+                  if self.is_eof() {
+                    return Some(HtmlToken::Eof);
+                  }
+                  self.append_attribute_value(c, /*is_name*/ false);
+                }
                 _ => {}
             }
 


### PR DESCRIPTION
This pull request introduces new states to the `HtmlTokenizer` in the `saba_core` module to handle different types of attribute values in HTML tokens. These changes enhance the tokenizer's capability to process single-quoted and unquoted attribute values correctly.

Enhancements to HTML tokenization:

* [`saba_core/src/renderer/html/token.rs`](diffhunk://#diff-8e5a3c41ba66c69d181955c4d468bcea826838096f8598c4b91b2aa673e37930R298-R321): Added handling for `State::AttributeValueSingleQuoted` to manage single-quoted attribute values and transition to `State::AfterAttributeValueQuoted` upon encountering a closing quote.
* [`saba_core/src/renderer/html/token.rs`](diffhunk://#diff-8e5a3c41ba66c69d181955c4d468bcea826838096f8598c4b91b2aa673e37930R298-R321): Added handling for `State::AttributeValueUnQuoted` to manage unquoted attribute values and transition to `State::BeforeAttributeName` upon encountering a space or to `State::Data` upon encountering a slash.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced HTML tokenization with improved handling of single-quoted and unquoted attribute values.
	- Introduced new states for better parsing of different quoting scenarios in HTML attributes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->