### PR TITLE
add scriptdateaendtagname

### DIFF
--- a/saba_core/src/renderer/html/token.rs
+++ b/saba_core/src/renderer/html/token.rs
@@ -391,6 +391,20 @@ impl Iterator for HtmlTokenizer {
                   self.state = State::ScriptData;
                   return Some(HtmlToken::Char('<'));
                 }
+                State::ScriptDataEndTagName => {
+                  if c == '>' {
+                    self.state = State::ScriptData;
+                    return self.take_latest_token();
+                  }
+                  if c.is_ascii_uppercase() {
+                    self.buf.push(c.to_ascii_lowercase());
+                    continue;
+                  }
+                  self.state = State::TemporaryBuffer;
+                  self.buf = String::from("</") + &self.buf;
+                  self.buf.push(c);
+                  continue;
+                }
                 _ => {}
             }
 


### PR DESCRIPTION
This pull request includes a significant change to the `impl Iterator for HtmlTokenizer` in the `saba_core/src/renderer/html/token.rs` file. The change introduces a new state, `State::ScriptDataEndTagName`, to handle the end tag names within script data.

Changes to HTML Tokenizer:

* Added a new state `State::ScriptDataEndTagName` to handle cases where the character is '>', an uppercase ASCII letter, or any other character, updating the state and buffer accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced HTML tokenizer with improved handling of script end tags, ensuring more accurate parsing of HTML content.

- **Bug Fixes**
	- Improved control flow for processing script tags, maintaining tokenization integrity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->