### PR TITLE
add TemporaryBuffer

### DIFF
--- a/saba_core/src/renderer/html/token.rs
+++ b/saba_core/src/renderer/html/token.rs
@@ -405,7 +405,16 @@ impl Iterator for HtmlTokenizer {
                   self.buf.push(c);
                   continue;
                 }
-                _ => {}
+                State::TemporaryBuffer =>{
+                  self.reconsume = true;
+                  if self.buf.chars().count() ==0 {
+                    self.state = State::ScriptData;
+                    continue;
+                  }
+                  let c = self.buf.chars().nth(0).expect("self.buf should have at least 1 char");
+                  self.buf.remove(0);
+                  return Some(HtmlToken::Char(c));
+                }
             }
 
         }


### PR DESCRIPTION
This pull request includes changes to the `HtmlTokenizer` implementation in the `saba_core` project. The most important change is the addition of a new state `State::TemporaryBuffer` to handle specific conditions during HTML tokenization.

Changes to `HtmlTokenizer`:

* Added a new state `State::TemporaryBuffer` to the `impl Iterator for HtmlTokenizer` in `saba_core/src/renderer/html/token.rs` to handle cases where the buffer is temporarily used and then emptied. This state reconsumes the character and transitions to `State::ScriptData` if the buffer is empty, otherwise it processes the first character in the buffer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new `TemporaryBuffer` state in the HTML tokenization process for improved character handling.
  
- **Bug Fixes**
	- Enhanced character processing during transitions between tokenization states, ensuring proper functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->