### PR TITLE
add empty token test

### DIFF
--- a/saba_core/src/renderer/html/token.rs
+++ b/saba_core/src/renderer/html/token.rs
@@ -431,3 +431,16 @@ impl Iterator for HtmlTokenizer {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::alloc::string::ToString;
+
+    #[test]
+    fn test_empty() {
+        let html = "".to_string();
+        let mut tokenizer = HtmlTokenizer::new(html.chars().collect());
+        assert!(tokenizer.next().is_none());
+    }
+}


### PR DESCRIPTION
This pull request introduces a new test module to the `HtmlTokenizer` implementation in the `saba_core/src/renderer/html/token.rs` file. The added test ensures that the tokenizer correctly handles an empty HTML input.

Key change:

* Added a test module with a test case to verify that the `HtmlTokenizer` returns `None` when given an empty string as input.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
	- Introduced a new test module for the `HtmlTokenizer` to ensure proper handling of empty input.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->