### PR TITLE
add tag test

### DIFF
--- a/saba_core/src/renderer/html/token.rs
+++ b/saba_core/src/renderer/html/token.rs
@@ -154,8 +154,7 @@ impl HtmlTokenizer {
     }
     fn take_latest_token(&mut self) -> Option<HtmlToken> {
         assert!(self.latest_token.is_some());
-        let t = self.latest_token.as_ref().cloned();
-        assert!(self.latest_token.is_none());
+        let t = self.latest_token.take();
         t
     }
 
@@ -442,5 +441,24 @@ mod tests {
         let html = "".to_string();
         let mut tokenizer = HtmlTokenizer::new(html.chars().collect());
         assert!(tokenizer.next().is_none());
+    }
+
+    #[test]
+    fn test_start_and_end_tag() {
+        let html = "<body></body>".to_string();
+        let mut tokenizer = HtmlTokenizer::new(html.chars().collect());
+        let expected = [
+            HtmlToken::StartTag {
+                tag: "body".to_string(),
+                self_closing: false,
+                attributes: Vec::new(),
+            },
+            HtmlToken::EndTag {
+                tag: "body".to_string(),
+            },
+        ];
+        for e in expected {
+            assert_eq!(Some(e), tokenizer.next());
+        }
     }
 }

--- a/saba_core/src/renderer/html/token.rs
+++ b/saba_core/src/renderer/html/token.rs
@@ -154,8 +154,7 @@ impl HtmlTokenizer {
     }
     fn take_latest_token(&mut self) -> Option<HtmlToken> {
         assert!(self.latest_token.is_some());
-        let t = self.latest_token.take();
-        t
+        self.latest_token.take()
     }
 
     fn set_self_closing_flag(&mut self) {


### PR DESCRIPTION
This pull request includes changes to the `saba_core/src/renderer/html/token.rs` file, focusing on improving the `HtmlTokenizer` implementation and expanding test coverage.

Improvements to `HtmlTokenizer`:

* Modified the `take_latest_token` method to use the `take` method instead of cloning and then asserting the token is none. This simplifies the code and ensures the token is taken directly.

Enhancements to test coverage:

* Added a new test `test_start_and_end_tag` to verify the correct tokenization of start and end tags for HTML elements. This ensures the tokenizer correctly identifies and processes start and end tags.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Improved token management in the HTML tokenizer for enhanced performance.
	- Added a test case to validate the parsing of start and end tags for the `<body>` element.

- **Bug Fixes**
	- Corrected the behavior of the token retrieval method to ensure proper ownership handling of tokens.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->