### PR TITLE
fix fail attribute test

### DIFF
--- a/saba_core/src/renderer/html/attribute.rs
+++ b/saba_core/src/renderer/html/attribute.rs
@@ -7,6 +7,12 @@ pub struct Attribute {
     value: String,
 }
 
+impl Default for Attribute {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl Attribute {
     pub fn new() -> Self {
         Self {


### PR DESCRIPTION
This pull request includes several changes to the `HtmlTokenizer` implementation in the `saba_core/src/renderer/html/token.rs` file, focusing on improving the state transitions and handling of specific characters during HTML tokenization. The most important changes include adding checks for the end of file (EOF), modifying state transitions for better handling of tag names and attribute values, and correcting the state assignment after encountering certain characters.

Improvements to state transitions:

* Added a check for EOF in the `State::EndTagOpen` state to return `HtmlToken::Eof` if the end of the file is reached.

* Modified the state transition in `State::TagName` to move to `State::Data` when encountering the '>' character instead of '/'.

* Changed the state transition in `State::AfterAttributeValueQuoted` to move to `State::BeforeAttributeName` when encountering a space character.

* Corrected the state transition in `State::AttributeValueUnQuoted` to move to `State::BeforeAttributeName` after reconsuming a character.

* Removed an unnecessary blank line in the `State::TagName` transition to improve code readability.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling of end-of-file scenarios in HTML tokenization, ensuring accurate EOF token generation.
	- Refined state transitions for attribute value parsing, enhancing overall parsing accuracy.

- **New Features**
	- Enhanced usability of the `Attribute` struct with a default implementation, allowing for easier instantiation with default values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->