### PR TITLE
add blank tag test

### DIFF
--- a/saba_core/src/renderer/html/token.rs
+++ b/saba_core/src/renderer/html/token.rs
@@ -507,4 +507,19 @@ mod tests {
             assert_eq!(Some(e), tokenizer.next());
         }
     }
+    #[test]
+    fn test_self_closing_tag() {
+        let html = "<img />".to_string();
+        let mut tokenizer = HtmlTokenizer::new(html.chars().collect());
+        let expected = [
+            HtmlToken::StartTag {
+                tag: "img".to_string(),
+                self_closing: true,
+                attributes: Vec::new(),
+            },
+        ];
+        for e in expected {
+            assert_eq!(Some(e), tokenizer.next());
+        }
+    }
 }

--- a/saba_core/src/renderer/html/token.rs
+++ b/saba_core/src/renderer/html/token.rs
@@ -511,13 +511,11 @@ mod tests {
     fn test_self_closing_tag() {
         let html = "<img />".to_string();
         let mut tokenizer = HtmlTokenizer::new(html.chars().collect());
-        let expected = [
-            HtmlToken::StartTag {
-                tag: "img".to_string(),
-                self_closing: true,
-                attributes: Vec::new(),
-            },
-        ];
+        let expected = [HtmlToken::StartTag {
+            tag: "img".to_string(),
+            self_closing: true,
+            attributes: Vec::new(),
+        }];
         for e in expected {
             assert_eq!(Some(e), tokenizer.next());
         }


### PR DESCRIPTION
This pull request includes a small change to the `saba_core/src/renderer/html/token.rs` file. The change adds a new test case for handling self-closing tags in the HTML tokenizer.

* [`saba_core/src/renderer/html/token.rs`](diffhunk://#diff-8e5a3c41ba66c69d181955c4d468bcea826838096f8598c4b91b2aa673e37930R510-R524): Added a new test case `test_self_closing_tag` to verify that the `HtmlTokenizer` correctly identifies and processes self-closing tags.