### PR TITLE
add script tag test

### DIFF
--- a/saba_core/src/renderer/html/token.rs
+++ b/saba_core/src/renderer/html/token.rs
@@ -520,4 +520,30 @@ mod tests {
             assert_eq!(Some(e), tokenizer.next());
         }
     }
+    #[test]
+    fn test_script_tag() {
+        let html = "<script>js code;</script>".to_string();
+        let mut tokenizer = HtmlTokenizer::new(html.chars().collect());
+        let expected = [
+            HtmlToken::StartTag {
+                tag: "script".to_string(),
+                self_closing: false,
+                attributes: Vec::new(),
+            },
+            HtmlToken::Char('j'),
+            HtmlToken::Char('s'),
+            HtmlToken::Char(' '),
+            HtmlToken::Char('c'),
+            HtmlToken::Char('o'),
+            HtmlToken::Char('d'),
+            HtmlToken::Char('e'),
+            HtmlToken::Char(';'),
+            HtmlToken::EndTag {
+                tag: "script".to_string(),
+            },
+        ];
+        for e in expected {
+            assert_eq!(Some(e), tokenizer.next());
+        }
+    }
 }


### PR DESCRIPTION
This pull request includes a new test case for the `HtmlTokenizer` in the `saba_core` module. The test case ensures that the tokenizer correctly processes `<script>` tags and their content.

New test case added:

* [`saba_core/src/renderer/html/token.rs`](diffhunk://#diff-8e5a3c41ba66c69d181955c4d468bcea826838096f8598c4b91b2aa673e37930R523-R548): Added `test_script_tag` to verify that the `HtmlTokenizer` correctly tokenizes a `<script>` tag and its JavaScript content.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new test to validate the tokenizer's handling of `<script>` tags in HTML.

- **Bug Fixes**
	- Enhanced coverage for processing JavaScript code within `<script>` tags.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->