### PR TITLE
add node

### DIFF
--- a/saba_core/src/renderer/dom/node.rs
+++ b/saba_core/src/renderer/dom/node.rs
@@ -1,1 +1,147 @@
-//todo
+use crate::renderer::html::attribute::Attribute;
+// use alloc::fmt::format;
+use alloc::format;
+use alloc::rc::Rc;
+use alloc::rc::Weak;
+use alloc::string::String;
+use alloc::vec::Vec;
+use core::cell::RefCell;
+use core::str::FromStr;
+
+#[derive(Debug, Clone)]
+pub struct Node {
+    pub kind: NodeKind,
+    window: Weak<RefCell<Window>>,
+    parent: Weak<RefCell<Node>>,
+    first_child: Option<Rc<RefCell<Node>>>,
+    last_child: Weak<Rc<RefCell<Node>>>,
+    previou_sibling: Weak<Rc<RefCell<Node>>>,
+    next_sibling: Option<Rc<RefCell<Node>>>,
+}
+
+impl Node {
+    pub fn new(kind: NodeKind) -> Self {
+        Self {
+            kind,
+            window: Weak::new(),
+            parent: Weak::new(),
+            first_child: None,
+            last_child: Weak::new(),
+            previou_sibling: Weak::new(),
+            next_sibling: None,
+        }
+    }
+    pub fn set_window(&mut self, window: Weak<RefCell<Window>>) {
+        self.window = window;
+    }
+    pub fn set_parent(&mut self, parent: Weak<RefCell<Node>>) {
+        self.parent = parent;
+    }
+    pub fn parent(&self) -> Weak<RefCell<Node>> {
+        self.parent.clone()
+    }
+    pub fn set_first_child(&mut self, first_child: Option<Rc<RefCell<Node>>>) {
+        self.first_child = first_child;
+    }
+    pub fn first_child(&self) -> Option<Rc<RefCell<Node>>> {
+        self.first_child.clone()
+    }
+    pub fn set_last_child(&mut self, last_child: Weak<Rc<RefCell<Node>>>) {
+        self.last_child = last_child;
+    }
+    pub fn last_child(&self) -> Weak<Rc<RefCell<Node>>> {
+        self.last_child.clone()
+    }
+    pub fn set_previous_sibling(&mut self, previous_sibling: Weak<Rc<RefCell<Node>>>) {
+        self.previou_sibling = previous_sibling;
+    }
+    pub fn previous_sibling(&self) -> Weak<Rc<RefCell<Node>>> {
+        self.previou_sibling.clone()
+    }
+    pub fn set_next_sibling(&mut self, next_sibling: Option<Rc<RefCell<Node>>>) {
+        self.next_sibling = next_sibling;
+    }
+    pub fn next_sibling(&self) -> Option<Rc<RefCell<Node>>> {
+        self.next_sibling.clone()
+    }
+}
+
+#[derive(Debug, Clone)]
+pub enum NodeKind {
+    /// https://dom.spec.whatwg.org/#interface-document
+    Document,
+    /// https://dom.spec.whatwg.org/#interface-element
+    Element(Element),
+    /// https://dom.spec.whatwg.org/#interface-text
+    Text(String),
+}
+
+#[derive(Debug, Clone)]
+pub struct Window {
+    document: Rc<RefCell<Node>>,
+}
+
+impl Window {
+    pub fn new() -> Self {
+        let window = Self {
+            document: Rc::new(RefCell::new(Node::new(NodeKind::Document))),
+        };
+        window
+            .document
+            .borrow_mut()
+            .set_window(Rc::downgrade(&Rc::new(RefCell::new(window.clone()))));
+
+        window
+    }
+    pub fn document(&self) -> Rc<RefCell<Node>> {
+        self.document.clone()
+    }
+}
+
+impl Default for Window {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Element {
+    kind: ElementKind,
+    attributes: Vec<Attribute>,
+}
+
+impl Element {
+    pub fn new(element_name: &str, attributes: Vec<Attribute>) -> Self {
+        Self {
+            kind: ElementKind::from_str(element_name)
+                .expect("failed to convert string to ElementKind"),
+            attributes,
+        }
+    }
+    pub fn kind(&self) -> ElementKind {
+        self.kind
+    }
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum ElementKind {
+    Html,
+    Head,
+    Style,
+    Script,
+    Body,
+}
+
+impl FromStr for ElementKind {
+    type Err = String;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "html" => Ok(ElementKind::Html),
+            "head" => Ok(ElementKind::Head),
+            "style" => Ok(ElementKind::Style),
+            "script" => Ok(ElementKind::Script),
+            "body" => Ok(ElementKind::Body),
+            _ => Err(format!("unimplement element name {:?}", s)),
+        }
+    }
+}


### PR DESCRIPTION
This pull request introduces a significant update to the `saba_core/src/renderer/dom/node.rs` file. The changes primarily involve the addition of a new `Node` structure and its associated methods, as well as the implementation of various enums and structs to represent different kinds of nodes and elements in a DOM-like structure.

### Key changes:

#### New Structures and Enums:
* Added `Node` struct with fields for node relationships and methods for setting and getting these relationships.
* Introduced `NodeKind` enum to represent different types of nodes, including `Document`, `Element`, and `Text`.
* Added `Window` struct with a `document` field and methods for creating and accessing the document node.
* Implemented `Element` struct with fields for element kind and attributes, along with methods to create and access elements.
* Defined `ElementKind` enum to represent various HTML element types and implemented `FromStr` trait for converting strings to `ElementKind`.

These changes establish a foundational structure for representing and manipulating a DOM-like hierarchy in the codebase.