### PR TITLE
add element method

### DIFF
--- a/saba_core/src/renderer/dom/node.rs
+++ b/saba_core/src/renderer/dom/node.rs
@@ -31,6 +31,21 @@ impl Node {
             next_sibling: None,
         }
     }
+    pub fn kind(&self) -> NodeKind {
+        self.kind.clone()
+    }
+    pub fn get_element(&self) -> Option<Element> {
+        match &self.kind {
+            NodeKind::Document | NodeKind::Text(_) => None,
+            NodeKind::Element(ref e) => Some(e.clone()),
+        }
+    }
+    pub fn element_kind(&self) -> Option<ElementKind> {
+        match &self.kind {
+            NodeKind::Document | NodeKind::Text(_) => None,
+            NodeKind::Element(ref e) => Some(e.kind()),
+        }
+    }
     pub fn set_window(&mut self, window: Weak<RefCell<Window>>) {
         self.window = window;
     }


### PR DESCRIPTION
This pull request adds new methods to the `Node` implementation in the `saba_core/src/renderer/dom/node.rs` file. These changes aim to enhance the functionality of the `Node` struct by providing additional ways to access and manipulate node data.

New methods added:

* [`kind`](diffhunk://#diff-c37f339a48e32c899b472dbc194da9331535956c7e963a4f5233a59be9c162d3R34-R48): Returns a clone of the node's kind.
* [`get_element`](diffhunk://#diff-c37f339a48e32c899b472dbc194da9331535956c7e963a4f5233a59be9c162d3R34-R48): Returns an `Option<Element>` based on the node's kind, specifically returning `None` for `Document` and `Text` node kinds and `Some` for `Element` node kinds.
* [`element_kind`](diffhunk://#diff-c37f339a48e32c899b472dbc194da9331535956c7e963a4f5233a59be9c162d3R34-R48): Returns an `Option<ElementKind>` based on the node's kind, similar to `get_element`, but returns the kind of the element if it exists.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced new methods to enhance the `Node` struct's functionality, allowing for better access to node types and associated elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->