### PR TITLE
Feature/add parser detail implementation

### DIFF
--- a/saba_core/src/renderer/dom/node.rs
+++ b/saba_core/src/renderer/dom/node.rs
@@ -148,6 +148,7 @@ pub enum ElementKind {
     P,
     H1,
     H2,
+    A,
 }
 
 impl FromStr for ElementKind {
@@ -162,6 +163,7 @@ impl FromStr for ElementKind {
             "p" => Ok(ElementKind::P),
             "h1" => Ok(ElementKind::H1),
             "h2" => Ok(ElementKind::H2),
+            "a" => Ok(ElementKind::A),
             _ => Err(format!("unimplement element name {:?}", s)),
         }
     }

--- a/saba_core/src/renderer/dom/node.rs
+++ b/saba_core/src/renderer/dom/node.rs
@@ -146,6 +146,8 @@ pub enum ElementKind {
     Script,
     Body,
     P,
+    H1,
+    H2,
 }
 
 impl FromStr for ElementKind {
@@ -158,6 +160,8 @@ impl FromStr for ElementKind {
             "script" => Ok(ElementKind::Script),
             "body" => Ok(ElementKind::Body),
             "p" => Ok(ElementKind::P),
+            "h1" => Ok(ElementKind::H1),
+            "h2" => Ok(ElementKind::H2),
             _ => Err(format!("unimplement element name {:?}", s)),
         }
     }

--- a/saba_core/src/renderer/dom/node.rs
+++ b/saba_core/src/renderer/dom/node.rs
@@ -14,8 +14,8 @@ pub struct Node {
     window: Weak<RefCell<Window>>,
     parent: Weak<RefCell<Node>>,
     first_child: Option<Rc<RefCell<Node>>>,
-    last_child: Weak<Rc<RefCell<Node>>>,
-    previou_sibling: Weak<Rc<RefCell<Node>>>,
+    last_child: Weak<RefCell<Node>>,
+    previous_sibling: Weak<RefCell<Node>>,
     next_sibling: Option<Rc<RefCell<Node>>>,
 }
 
@@ -27,7 +27,7 @@ impl Node {
             parent: Weak::new(),
             first_child: None,
             last_child: Weak::new(),
-            previou_sibling: Weak::new(),
+            previous_sibling: Weak::new(),
             next_sibling: None,
         }
     }
@@ -61,17 +61,17 @@ impl Node {
     pub fn first_child(&self) -> Option<Rc<RefCell<Node>>> {
         self.first_child.clone()
     }
-    pub fn set_last_child(&mut self, last_child: Weak<Rc<RefCell<Node>>>) {
+    pub fn set_last_child(&mut self, last_child: Weak<RefCell<Node>>) {
         self.last_child = last_child;
     }
-    pub fn last_child(&self) -> Weak<Rc<RefCell<Node>>> {
+    pub fn last_child(&self) -> Weak<RefCell<Node>> {
         self.last_child.clone()
     }
-    pub fn set_previous_sibling(&mut self, previous_sibling: Weak<Rc<RefCell<Node>>>) {
-        self.previou_sibling = previous_sibling;
+    pub fn set_previous_sibling(&mut self, previous_sibling: Weak<RefCell<Node>>) {
+        self.previous_sibling = previous_sibling;
     }
-    pub fn previous_sibling(&self) -> Weak<Rc<RefCell<Node>>> {
-        self.previou_sibling.clone()
+    pub fn previous_sibling(&self) -> Weak<RefCell<Node>> {
+        self.previous_sibling.clone()
     }
     pub fn set_next_sibling(&mut self, next_sibling: Option<Rc<RefCell<Node>>>) {
         self.next_sibling = next_sibling;

--- a/saba_core/src/renderer/dom/node.rs
+++ b/saba_core/src/renderer/dom/node.rs
@@ -145,6 +145,7 @@ pub enum ElementKind {
     Style,
     Script,
     Body,
+    P,
 }
 
 impl FromStr for ElementKind {
@@ -156,6 +157,7 @@ impl FromStr for ElementKind {
             "style" => Ok(ElementKind::Style),
             "script" => Ok(ElementKind::Script),
             "body" => Ok(ElementKind::Body),
+            "p" => Ok(ElementKind::P),
             _ => Err(format!("unimplement element name {:?}", s)),
         }
     }

--- a/saba_core/src/renderer/html/parser.rs
+++ b/saba_core/src/renderer/html/parser.rs
@@ -43,6 +43,11 @@ impl HtmlParser {
             t,
         }
     }
+    fn create_char(&self,c: char) -> Node {
+      let mut s = String::new();
+      s.push(c);
+      Node::new(NodeKind::Text(s))
+    }
     fn create_element(&self, tag: &str, attributes: Vec<Attribute>) -> Node {
         Node::new(NodeKind::Element(Element::new(tag, attributes)))
     }
@@ -126,12 +131,6 @@ impl HtmlParser {
         }
       }
       false
-    }
-
-    fn create_char(&self,c: char) -> Node {
-      let mut s = String::new();
-      s.push(c);
-      Node::new(NodeKind::Text(s))
     }
 
     fn insert_char(&mut self,c:char){

--- a/saba_core/src/renderer/html/parser.rs
+++ b/saba_core/src/renderer/html/parser.rs
@@ -8,6 +8,7 @@ use crate::renderer::html::token::{HtmlToken, HtmlTokenizer};
 
 use alloc::rc::Rc;
 use alloc::vec::Vec;
+use alloc::string::String;
 use core::cell::RefCell;
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
@@ -125,6 +126,50 @@ impl HtmlParser {
         }
       }
       false
+    }
+
+    fn create_char(&self,c: char) -> Node {
+      let mut s = String::new();
+      s.push(c);
+      Node::new(NodeKind::Text(s))
+    }
+
+    fn insert_char(&mut self,c:char){
+      let current = match self.stack_of_open_elements.last() {
+        Some(n) => n.clone(),
+        None => return,
+      };
+
+      if let NodeKind::Text(ref mut s) = current.borrow_mut().kind{
+        s.push(c);
+        return;
+      }
+
+      if c== '\n' || c == ' '{
+        return;
+      }
+
+      let node = Rc::new(RefCell::new(self.create_char(c)));
+
+      if current.borrow().first_child().is_some(){
+        current
+        .borrow()
+        .first_child()
+        .unwrap()
+        .borrow_mut()
+        .set_next_sibling(Some(node.clone()));
+      node.borrow_mut().set_privious_sibling(Tc::downgrade(
+        &current
+        .borrow()
+        .first_child()
+        .expect("failed to get a first child"),
+      ));
+      } else{
+        current.borrow_mut().set_first_child(Some(node.clone()));
+      }
+      current.borrow_mut().set_last_child(Rc::downgrade(&node));
+      node.borrow_mut().set_parent(Rc::downgrade(&current));
+      self.stack_of_open_elements.push(node);
     }
 
     pub fn construct_tree(&mut self) -> Rc<RefCell<Window>> {

--- a/saba_core/src/renderer/html/parser.rs
+++ b/saba_core/src/renderer/html/parser.rs
@@ -89,6 +89,18 @@ impl HtmlParser {
         self.stack_of_open_elements.push(node);
     }
 
+    fn pop_current_node(&mut self, kind: ElementKind) -> bool {
+        let current = match self.stack_of_open_elements.last() {
+            Some(n) => n.clone(),
+            None => return false,
+        };
+        if current.borrow().element_kind() == Some(element_kind) {
+            self.stack_of_open_elements.pop();
+            return true;
+        }
+        false
+    }
+
     pub fn construct_tree(&mut self) -> Rc<RefCell<Window>> {
         let mut token = self.t.next();
         while token.is_some() {

--- a/saba_core/src/renderer/html/parser.rs
+++ b/saba_core/src/renderer/html/parser.rs
@@ -331,6 +331,11 @@ impl HtmlParser {
                             token = self.t.next();
                             continue;
                           }
+                          "a" => {
+                            self.insert_element(tag, attributes.to_vec());
+                            token = self.t.next();
+                            continue;
+                          }
                           _ => {
                             token = self.t.next();
                           }
@@ -362,6 +367,13 @@ impl HtmlParser {
                             continue;
                           }
                           "h1" | "h2" => {
+                            let element_kind = ElementKind::from_str(tag)
+                            .expect("failed to convert string to ElementKind");
+                            token = self.t.next();
+                            self.pop_until(element_kind);
+                            continue;
+                          }
+                          "a" => {
                             let element_kind = ElementKind::from_str(tag)
                             .expect("failed to convert string to ElementKind");
                             token = self.t.next();

--- a/saba_core/src/renderer/html/parser.rs
+++ b/saba_core/src/renderer/html/parser.rs
@@ -101,6 +101,32 @@ impl HtmlParser {
         false
     }
 
+    fn pop_until(&mut self, kind: ElementKind) {
+        assert!(
+            self.contain_in_stack(element_kind),
+            "stack doesn't have an element {:?}",
+            element_kind,
+        );
+        loop {
+            let current = self.stack_of_open_elements.pop(){
+                Some(n) => n,
+                None => return,
+            };
+            if current.borrow().element_kind() == Some(element_kind) {
+                break;
+            }
+        }
+    }
+
+    fn contain_in_stack(&mut self, element_kind: ElementKind) -> bool {
+      for i in 0..self.stack_of_open_elements.len() {
+        if self.stack_of_open_elements[i].borrow().element_kind() == Some(element_kind) {
+          return true;
+        }
+      }
+      false
+    }
+
     pub fn construct_tree(&mut self) -> Rc<RefCell<Window>> {
         let mut token = self.t.next();
         while token.is_some() {

--- a/saba_core/src/renderer/html/parser.rs
+++ b/saba_core/src/renderer/html/parser.rs
@@ -316,6 +316,25 @@ impl HtmlParser {
                 }
                 InsertionMode::InBody => {
                     match token {
+                        Some(HtmlToken::StartTag {
+                          ref tag,
+                          self_closing: _,
+                          ref attributes,
+                        }) => match tag.as_str() {
+                          "p" => {
+                            self.insert_element(tag, attributes.to_vec());
+                            token = self.t.next();
+                            continue;
+                          }
+                          "h1" | "h2" =>{
+                            self.insert_element(tag, attributes.to_vec());
+                            token = self.t.next();
+                            continue;
+                          }
+                          _ => {
+                            token = self.t.next();
+                          }
+                        },
                         Some(HtmlToken::EndTag { ref tag }) => match tag.as_str() {
                             "body" => {
                                 self.mode = InsertionMode::AfterBody;
@@ -335,6 +354,21 @@ impl HtmlParser {
                                 }
                                 continue;
                             }
+                            "p" => {
+                              let element_kind = ElementKind::from_str(tag)
+                              .expect("failed to convert string to ElementKind");
+                            token = self.t.next();
+                            self.pop_until(element_kind);
+                            continue;
+                          }
+                          "h1" | "h2" => {
+                            let element_kind = ElementKind::from_str(tag)
+                            .expect("failed to convert string to ElementKind");
+                            token = self.t.next();
+                            self.pop_until(element_kind);
+                            continue;
+                          }
+
                             _ => {
                                 token = self.t.next();
                             }

--- a/saba_core/src/renderer/html/parser.rs
+++ b/saba_core/src/renderer/html/parser.rs
@@ -1,1 +1,304 @@
+use crate::renderer::dom::node::Element;
+use crate::renderer::dom::node::ElementKind;
+use crate::renderer::dom::node::Node;
+use crate::renderer::dom::node::NodeKind;
+use crate::renderer::dom::node::Window;
+use crate::renderer::html::attribute::Attribute;
+use crate::renderer::html::token::{HtmlToken, HtmlTokenizer};
 
+use alloc::rc::Rc;
+use alloc::vec::Vec;
+use core::cell::RefCell;
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum InsertionMode {
+    Initial,
+    BeforeHtml,
+    BeforeHead,
+    InHead,
+    AfterHead,
+    InBody,
+    Text,
+    AfterBody,
+    AfterAfterBody,
+}
+
+#[derive(Debug, Clone)]
+pub struct HtmlParser {
+    window: Rc<RefCell<Window>>,
+    mode: InsertionMode,
+    original_insertion_mode: InsertionMode,
+    stack_of_open_elements: Vec<Rc<RefCell<Node>>>,
+    t: HtmlTokenizer,
+}
+
+impl HtmlParser {
+    pub fn new(t: HtmlTokenizer) -> Self {
+        Self {
+            window: Rc::new(RefCell::new(Window::new())),
+            mode: InsertionMode::Initial,
+            original_insertion_mode: InsertionMode::Initial,
+            stack_of_open_elements: Vec::new(),
+            t,
+        }
+    }
+    fn create_element(&self, tag: &str, attributes: Vec<Attribute>) -> Node {
+        Node::new(NodeKind::Element(Element::new(tag, attributes)))
+    }
+    fn insert_element(&mut self, tag: &str, attributes: Vec<Attribute>) {
+        let window = self.window.borrow();
+        let current = match self.stack_of_open_elements.last() {
+            Some(n) => n.clone(),
+            None => window.document(),
+        };
+
+        let node = Rc::new(RefCell::new(self.create_element(tag, attributes)));
+
+        if current.borrow().first_child().is_some() {
+            let mut last_sibiling = current.borrow().first_child();
+            loop {
+                last_sibiling = match last_sibiling {
+                    Some(ref node) => {
+                        if node.borrow().next_sibling().is_some() {
+                            node.borrow().next_sibling()
+                        } else {
+                            break;
+                        }
+                    }
+                    None => unimplemented!("last_sibiling should be Some"),
+                }
+            }
+
+            last_sibiling
+                .unwrap()
+                .borrow_mut()
+                .set_next_sibling(Some(node.clone()));
+            node.borrow_mut().set_previous_sibling(Rc::downgrade(
+                &current
+                    .borrow()
+                    .first_child()
+                    .expect("failed to get a first child"),
+            ))
+        } else {
+            current.borrow_mut().set_first_child(Some(node.clone()));
+        }
+
+        current.borrow_mut().set_last_child(Rc::downgrade(&node));
+        node.borrow_mut().set_parent(Rc::downgrade(&current));
+
+        self.stack_of_open_elements.push(node);
+    }
+
+    pub fn construct_tree(&mut self) -> Rc<RefCell<Window>> {
+        let mut token = self.t.next();
+        while token.is_some() {
+            match self.mode {
+                InsertionMode::Initial => {
+                    if let Some(HtmlToken::Char(_)) = token {
+                        token = self.t.next();
+                        continue;
+                    }
+
+                    self.mode = InsertionMode::BeforeHtml;
+                    continue;
+                }
+                InsertionMode::BeforeHtml => {
+                    match token {
+                        Some(HtmlToken::Char(c)) => {
+                            if c == ' ' || c == '\n' {
+                                token = self.t.next();
+                                continue;
+                            }
+                        }
+                        Some(HtmlToken::StartTag {
+                            ref tag,
+                            self_closing: _,
+                            ref attributes,
+                        }) => {
+                            if tag == "html" {
+                                self.insert_element(tag, attributes.to_vec());
+                                self.mode = InsertionMode::BeforeHead;
+                                token = self.t.next();
+                                continue;
+                            }
+                        }
+                        Some(HtmlToken::Eof) | None => {
+                            return self.window.clone();
+                        }
+                        _ => {}
+                    }
+                    self.insert_element("html", Vec::new());
+                    self.mode = InsertionMode::BeforeHead;
+                    continue;
+                }
+                InsertionMode::BeforeHead => match token {
+                    Some(HtmlToken::Char(c)) => {
+                        if c == ' ' || c == '\n' {
+                            token = self.t.next();
+                            continue;
+                        }
+                    }
+                    Some(HtmlToken::StartTag {
+                        ref tag,
+                        self_closing: _,
+                        ref attributes,
+                    }) => {
+                        if tag == "head" {
+                            self.insert_element(tag, attributes.to_vec());
+                            self.mode = InsertionMode::InHead;
+                            token = self.t.next();
+                            continue;
+                        }
+                    }
+                    Some(HtmlToken::Eof) | None => {
+                        return self.window.clone();
+                    }
+                    _ => {}
+                },
+                InsertionMode::InHead => {
+                    match token {
+                        Some(HtmlToken::Char(c)) => {
+                            if c == ' ' || c == '\n' {
+                                self.insert_char(c);
+                                token = self.t.next();
+                                continue;
+                            }
+                        }
+                        Some(HtmlToken::StartTag {
+                            ref tag,
+                            self_closing: _,
+                            ref attributes,
+                        }) => {
+                            if tag == "style" || tag == "script" {
+                                self.insert_element(tag, attributes.to_vec());
+                                self.original_insertion_mode = self.mode;
+                                self.mode = InsertionMode::Text;
+                                token = self.t.next();
+                                continue;
+                            }
+                            if tag == "body" {
+                                self.pup_until(ElementKind::Head);
+                                self.mode = InsertionMode::AfterHead;
+                                continue;
+                            }
+                            if let Ok(_element_kind) = ElementKind::from_str(tag) {
+                                self.pop_until(ElemenetKind::Head);
+                                self.mode = InsertionMode::AfterHead;
+                                continue;
+                            }
+                        }
+                        Some(HtmlToken::EndTag { ref tag }) => {
+                            if tag == "head" {
+                                self.mode = InsertionMode::AfterHead;
+                                token = self.t.next();
+                                self.pup_until(ElementKind::Head);
+                                continue;
+                            }
+                        }
+                        Some(HtmlToken::Eof) | None => {
+                            return self.window.clone();
+                        }
+                    }
+                    token = self.t.next();
+                    continue;
+                }
+                InsertionMode::AfterHead => {
+                    match token {
+                        Some(HtmlToken::Char(c)) => {
+                            if c == ' ' || c == '\n' {
+                                self.insert_char(c);
+                                token = self.t.next();
+                                continue;
+                            }
+                        }
+                        Some(HtmlToken::StartTag {
+                            ref tag,
+                            self_closing: _,
+                            ref attributes,
+                        }) => {
+                            if tag == "body" {
+                                self.insert_element(tag, attributes.to_vec());
+                                token = self.t.next();
+                                self.mode = InsertionMode::InBody;
+                                continue;
+                            }
+                        }
+                        Some(HtmlToken::Eof) | None => {
+                            return self.window.clone();
+                        }
+                        _ => {}
+                    }
+                    self.insert_element("body", Vec::new());
+                    self.mode = InsertionMode::InBody;
+                    continue;
+                }
+                InsertionMode::InBody => {
+                    match token {
+                        Some(HtmlToken::EndTag { ref tag }) => match tag.as_str() {
+                            "body" => {
+                                self.mode = InsertionMode::AfterBody;
+                                token = self.t.next();
+                                if !self.contain_in_stack(ElementKind::Body) {
+                                    continue;
+                                }
+                                self.pup_until(ElementKind::Body);
+                                continue;
+                            }
+                            "html" => {
+                                if self.pop_current_node(ElementKind::Body) {
+                                    self.mode = InsertionMode::AfterBody;
+                                    assert!(self.pup_current_node(ElementKind::Html));
+                                } else {
+                                    token = self.t.next();
+                                }
+                                continue;
+                            }
+                            _ => {
+                                token = self.t.next();
+                            }
+                        },
+                        Some(HtmlToken::Eof) | None => {
+                            return self.window.clone();
+                        }
+                        _ => {}
+                    }
+                    self.mode = self.original_insertion_mode;
+                }
+                InsertionMode::AfterBody => {
+                    match token {
+                        Some(HtmlToken::Char(c)) => {
+                            token = self.t.next();
+                            continue;
+                        }
+                        Some(HtmlToken::EndTag { ref tag }) => {
+                            if tag == "html" {
+                                self.mode = InsertionMode::AfterAfterBody;
+                                token = self.t.next();
+                                continue;
+                            }
+                        }
+                        Some(HtmlToken::Eof) | None => {
+                            return self.window.clone();
+                        }
+                        _ => {}
+                    }
+                    self.mode = InsertionMode::InBody;
+                }
+                InsertionMode::AfterAfterBody => {
+                    match token {
+                        Some(HtmlToken::Char(c)) => {
+                            token = self.t.next();
+                            continue;
+                        }
+                        Some(HtmlToken::Eof) | None => {
+                            return self.window.clone();
+                        }
+                        _ => {}
+                    }
+                    self.mode = InsertionMode::InBody;
+                }
+            }
+        }
+        self.window.clone()
+    }
+}


### PR DESCRIPTION
This pull request includes several changes to the `saba_core/src/renderer/dom/node.rs` file, primarily focused on fixing typos and extending the `ElementKind` enum. The most important changes include correcting the spelling of `previous_sibling`, removing unnecessary `Rc` wrappers, and adding new HTML elements to the `ElementKind` enum.

### Typo Fixes and Code Simplification:
* Corrected the spelling of `previous_sibling` from `previou_sibling` to `previous_sibling` in the `Node` struct and its associated methods. [[1]](diffhunk://#diff-c37f339a48e32c899b472dbc194da9331535956c7e963a4f5233a59be9c162d3L17-R18) [[2]](diffhunk://#diff-c37f339a48e32c899b472dbc194da9331535956c7e963a4f5233a59be9c162d3L30-R30) [[3]](diffhunk://#diff-c37f339a48e32c899b472dbc194da9331535956c7e963a4f5233a59be9c162d3L64-R74)
* Removed unnecessary `Rc` wrappers from `last_child` and `previous_sibling` fields and methods in the `Node` struct. [[1]](diffhunk://#diff-c37f339a48e32c899b472dbc194da9331535956c7e963a4f5233a59be9c162d3L17-R18) [[2]](diffhunk://#diff-c37f339a48e32c899b472dbc194da9331535956c7e963a4f5233a59be9c162d3L64-R74)

### Enum Extension:
* Added new HTML elements `P`, `H1`, `H2`, and `A` to the `ElementKind` enum.
* Updated the `FromStr` implementation for `ElementKind` to handle the new elements `P`, `H1`, `H2`, and `A`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new HTML parser with enhanced functionality, including various insertion modes and methods for managing DOM elements.
	- Added new variants to the `ElementKind` enum to support additional HTML elements.

- **Bug Fixes**
	- Improved type correctness in the `Node` struct by updating field types and renaming for clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->