### PR TITLE
add partialeq

### DIFF
--- a/saba_core/src/renderer/dom/node.rs
+++ b/saba_core/src/renderer/dom/node.rs
@@ -19,6 +19,12 @@ pub struct Node {
     next_sibling: Option<Rc<RefCell<Node>>>,
 }
 
+impl PartialEq for Node {
+    fn eq(&self, other: &Self) -> bool {
+        self.kind == other.kind
+    }
+}
+
 impl Node {
     pub fn new(kind: NodeKind) -> Self {
         Self {
@@ -89,6 +95,19 @@ pub enum NodeKind {
     Element(Element),
     /// https://dom.spec.whatwg.org/#interface-text
     Text(String),
+}
+
+impl PartialEq for NodeKind {
+    fn eq(&self, other: &Self) -> bool {
+        match &self {
+            NodeKind::Document => matches!(other, NodeKind::Document),
+            NodeKind::Element(e1) => match &other {
+                NodeKind::Element(e2) => e1.kind == e2.kind,
+                _ => false,
+            },
+            NodeKind::Text(_) => matches!(other, NodeKind::Text(_)),
+        }
+    }
 }
 
 #[derive(Debug, Clone)]


### PR DESCRIPTION
This pull request introduces the implementation of the `PartialEq` trait for the `Node` and `NodeKind` structs in the `saba_core/src/renderer/dom/node.rs` file. This change allows for equality comparisons between instances of these structs.

Equality comparison implementation:

* [`saba_core/src/renderer/dom/node.rs`](diffhunk://#diff-c37f339a48e32c899b472dbc194da9331535956c7e963a4f5233a59be9c162d3R22-R27): Implemented the `PartialEq` trait for `Node` to compare the `kind` field for equality.
* [`saba_core/src/renderer/dom/node.rs`](diffhunk://#diff-c37f339a48e32c899b472dbc194da9331535956c7e963a4f5233a59be9c162d3R100-R112): Implemented the `PartialEq` trait for `NodeKind` to enable matching based on the specific variant and its contents.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced equality comparison for `Node` and `NodeKind` structures, enhancing comparison capabilities.
  
- **Chores**
	- Removed an unused import statement to streamline the code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->