### PR TITLE
add parser empty test

### DIFF
--- a/saba_core/src/renderer/html/parser.rs
+++ b/saba_core/src/renderer/html/parser.rs
@@ -464,3 +464,18 @@ impl HtmlParser {
         self.window.clone()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::alloc::string::ToString;
+
+    #[test]
+    fn test_empty() {
+        let html = "".to_string();
+        let t = HtmlTokenizer::new(html);
+        let window = HtmlParser::new(t).construct_tree();
+        let expected = Rc::new(RefCell::new(Node::new(NodeKind::Document)));
+        assert_eq!(expected, window.borrow().document());
+    }
+}

--- a/saba_core/src/renderer/html/token.rs
+++ b/saba_core/src/renderer/html/token.rs
@@ -51,13 +51,13 @@ pub struct HtmlTokenizer {
 }
 
 impl HtmlTokenizer {
-    pub fn new(input: Vec<char>) -> Self {
+    pub fn new(html: String) -> Self {
         Self {
             state: State::Data,
             pos: 0,
             reconsume: false,
             latest_token: None,
-            input,
+            input: html.chars().collect(),
             buf: String::new(),
         }
     }


### PR DESCRIPTION
This pull request includes changes to the `saba_core/src/renderer/html` module, focusing on the `HtmlParser` and `HtmlTokenizer` components. The main changes involve adding tests for the `HtmlParser` and modifying the constructor for `HtmlTokenizer`.

### Testing Enhancements:

* Added a new test module for `HtmlParser` with a test case `test_empty` to verify the construction of an empty HTML document tree. (`saba_core/src/renderer/html/parser.rs`)

### Codebase Modifications:

* Changed the `HtmlTokenizer` constructor to accept a `String` instead of a `Vec<char>`, simplifying the initialization process by converting the string to characters internally. (`saba_core/src/renderer/html/token.rs`)