### PR TITLE
add parser body test

### DIFF
--- a/saba_core/src/renderer/html/parser.rs
+++ b/saba_core/src/renderer/html/parser.rs
@@ -478,4 +478,50 @@ mod tests {
         let expected = Rc::new(RefCell::new(Node::new(NodeKind::Document)));
         assert_eq!(expected, window.borrow().document());
     }
+
+    #[test]
+    fn test_body() {
+        let html = "<html><head></head><body></body></html>".to_string();
+        let t = HtmlTokenizer::new(html);
+        let window = HtmlParser::new(t).construct_tree();
+        let document = window.borrow().document();
+        assert_eq!(
+            Rc::new(RefCell::new(Node::new(NodeKind::Document))),
+            document
+        );
+
+        let html = document
+            .borrow()
+            .first_child()
+            .expect("failed to get a first child of document");
+        assert_eq!(
+            Rc::new(RefCell::new(Node::new(NodeKind::Element(Element::new(
+                "html",
+                Vec::new()
+            ))))),
+            html
+        );
+        let head = html
+            .borrow()
+            .first_child()
+            .expect("failed to get a first child of html");
+        assert_eq!(
+            Rc::new(RefCell::new(Node::new(NodeKind::Element(Element::new(
+                "head",
+                Vec::new()
+            ))))),
+            head
+        );
+        let body = head
+            .borrow()
+            .next_sibling()
+            .expect("failed to get a next sibling of head");
+        assert_eq!(
+            Rc::new(RefCell::new(Node::new(NodeKind::Element(Element::new(
+                "body",
+                Vec::new()
+            ))))),
+            body
+        );
+    }
 }


### PR DESCRIPTION
This pull request includes a new test case in the `saba_core` module to ensure the HTML parser correctly constructs the document tree. The most important change is the addition of the `test_body` function in the `html/parser.rs` file.

### New Test Case:

* [`saba_core/src/renderer/html/parser.rs`](diffhunk://#diff-43c68d24578489e7dcd4175f0f33d08ac3b2d8ac8be72bc9b4020bb4dcf0838fR481-R526): Added `test_body` function to verify that the HTML parser correctly constructs the document tree with `<html>`, `<head>`, and `<body>` elements.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
	- Added a new test case to verify the parsing of a simple HTML document structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->