### PR TITLE
add parser text test

### DIFF
--- a/saba_core/src/renderer/html/parser.rs
+++ b/saba_core/src/renderer/html/parser.rs
@@ -467,6 +467,7 @@ impl HtmlParser {
 
 #[cfg(test)]
 mod tests {
+
     use super::*;
     use crate::alloc::string::ToString;
 
@@ -522,6 +523,53 @@ mod tests {
                 Vec::new()
             ))))),
             body
+        );
+    }
+
+    #[test]
+    fn test_text() {
+        let html = "<html><head></head><body>text</body></html>".to_string();
+        let t = HtmlTokenizer::new(html);
+        let window = HtmlParser::new(t).construct_tree();
+        let document = window.borrow().document();
+        assert_eq!(
+            Rc::new(RefCell::new(Node::new(NodeKind::Document))),
+            document
+        );
+
+        let html = document
+            .borrow()
+            .first_child()
+            .expect("failed to get a first child of document");
+        assert_eq!(
+            Rc::new(RefCell::new(Node::new(NodeKind::Element(Element::new(
+                "html",
+                Vec::new()
+            ))))),
+            html
+        );
+        let body = html
+            .borrow()
+            .first_child()
+            .expect("failed to get a first child of document")
+            .borrow()
+            .next_sibling()
+            .expect("failed to get a next sibling of head");
+        assert_eq!(
+            Rc::new(RefCell::new(Node::new(NodeKind::Element(Element::new(
+                "body",
+                Vec::new()
+            ))))),
+            body
+        );
+
+        let text = body
+            .borrow()
+            .first_child()
+            .expect("failed to get a first child of body");
+        assert_eq!(
+            Rc::new(RefCell::new(Node::new(NodeKind::Text("text".to_string())))),
+            text
         );
     }
 }


### PR DESCRIPTION
This pull request introduces a new test case to the `saba_core/src/renderer/html/parser.rs` file. The most important changes include adding a test function to verify the parsing of a simple HTML document containing text.

New test case addition:

* [`saba_core/src/renderer/html/parser.rs`](diffhunk://#diff-43c68d24578489e7dcd4175f0f33d08ac3b2d8ac8be72bc9b4020bb4dcf0838fR528-R574): Added a new test function `test_text` to verify the parsing of an HTML document with a text node. This includes checks for the document structure and node types.

Minor adjustments:

* [`saba_core/src/renderer/html/parser.rs`](diffhunk://#diff-43c68d24578489e7dcd4175f0f33d08ac3b2d8ac8be72bc9b4020bb4dcf0838fR470): Added a blank line for better readability in the test module.