### PR TITLE
add multiple node test

### DIFF
--- a/saba_core/src/renderer/html/parser.rs
+++ b/saba_core/src/renderer/html/parser.rs
@@ -470,6 +470,7 @@ mod tests {
 
     use super::*;
     use crate::alloc::string::ToString;
+    use alloc::vec;
 
     #[test]
     fn test_empty() {
@@ -567,6 +568,70 @@ mod tests {
             .borrow()
             .first_child()
             .expect("failed to get a first child of body");
+        assert_eq!(
+            Rc::new(RefCell::new(Node::new(NodeKind::Text("text".to_string())))),
+            text
+        );
+    }
+
+    #[test]
+    fn test_multiple_nodes() {
+        let html = "<html><head></head><body><p><a foo=bar>text</a></p></body></html>".to_string();
+        let t = HtmlTokenizer::new(html);
+        let window = HtmlParser::new(t).construct_tree();
+        let document = window.borrow().document();
+
+        let body = document
+            .borrow()
+            .first_child()
+            .expect("failed to get a first child of document")
+            .borrow()
+            .first_child()
+            .expect("failed to get a first child of document")
+            .borrow()
+            .next_sibling()
+            .expect("failed to get a next sibling of head");
+        assert_eq!(
+            Rc::new(RefCell::new(Node::new(NodeKind::Element(Element::new(
+                "body",
+                Vec::new()
+            ))))),
+            body
+        );
+        let p = body
+            .borrow()
+            .first_child()
+            .expect("failed to get a first child of body");
+        assert_eq!(
+            Rc::new(RefCell::new(Node::new(NodeKind::Element(Element::new(
+                "p",
+                Vec::new()
+            ))))),
+            p
+        );
+
+        let mut attr = Attribute::new();
+        attr.add_char('f', true);
+        attr.add_char('o', true);
+        attr.add_char('o', true);
+        attr.add_char('b', true);
+        attr.add_char('a', true);
+        attr.add_char('r', true);
+        let a = p
+            .borrow()
+            .first_child()
+            .expect("failed to get a first child of p");
+        assert_eq!(
+            Rc::new(RefCell::new(Node::new(NodeKind::Element(Element::new(
+                "a",
+                vec![attr]
+            ))))),
+            a
+        );
+        let text = a
+            .borrow()
+            .first_child()
+            .expect("failed to get a first child of a");
         assert_eq!(
             Rc::new(RefCell::new(Node::new(NodeKind::Text("text".to_string())))),
             text


### PR DESCRIPTION
This pull request includes changes to the `saba_core/src/renderer/html/parser.rs` file to enhance the test coverage for the HTML parser. The most important changes include adding a new test for parsing multiple nodes and importing the `vec` macro from the `alloc` crate.

Enhancements to test coverage:

* [`saba_core/src/renderer/html/parser.rs`](diffhunk://#diff-43c68d24578489e7dcd4175f0f33d08ac3b2d8ac8be72bc9b4020bb4dcf0838fR576-R639): Added a new test `test_multiple_nodes` to ensure the parser correctly constructs a tree from an HTML string with multiple nodes.

Codebase improvements:

* [`saba_core/src/renderer/html/parser.rs`](diffhunk://#diff-43c68d24578489e7dcd4175f0f33d08ac3b2d8ac8be72bc9b4020bb4dcf0838fR473): Imported the `vec` macro from the `alloc` crate to facilitate the creation of vectors in tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
	- Introduced a new test case to validate the parsing of nested HTML elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->