### PR TITLE
add css token

### DIFF
--- a/saba_core/src/renderer/css/token.rs
+++ b/saba_core/src/renderer/css/token.rs
@@ -1,1 +1,17 @@
-// todo
+use alloc::string::String;
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum CssToken {
+    HashToken(String),
+    Delim(char),
+    Number(f64),
+    Colon,
+    SemiColon,
+    OpenParenthesis,
+    CloseParenthesis,
+    OpenCurly,
+    CloseCurly,
+    Ident(String),
+    StringToken(String),
+    AtKeyword(String),
+}


### PR DESCRIPTION
This pull request includes significant changes to the `saba_core/src/renderer/css/token.rs` file, focusing on defining and implementing the `CssToken` enum to represent various CSS tokens.

Key changes:

* [`saba_core/src/renderer/css/token.rs`](diffhunk://#diff-9f1847a277eee073547b9448e39e6349855a2d84490a5998987f235a29688125L1-R17): Added the `CssToken` enum with variants to represent different types of CSS tokens, including `HashToken`, `Delim`, `Number`, `Colon`, `SemiColon`, `OpenParenthesis`, `CloseParenthesis`, `OpenCurly`, `CloseCurly`, `Ident`, `StringToken`, and `AtKeyword`. This change also includes the necessary `use` statement for `alloc::string::String` and derives traits for `Debug`, `Clone`, and `PartialEq`.