### PR TITLE
add css tokenizer

### DIFF
--- a/saba_core/src/renderer/css/token.rs
+++ b/saba_core/src/renderer/css/token.rs
@@ -1,4 +1,5 @@
 use alloc::string::String;
+use alloc::vec::Vec;
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum CssToken {
@@ -14,4 +15,19 @@ pub enum CssToken {
     Ident(String),
     StringToken(String),
     AtKeyword(String),
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct CssTokenizer {
+    pos: usize,
+    input: Vec<char>,
+}
+
+impl CssTokenizer {
+    pub fn new(css: String) -> Self {
+        Self {
+            pos: 0,
+            input: css.chars().collect(),
+        }
+    }
 }


### PR DESCRIPTION
This pull request introduces a new struct and associated implementation to the `saba_core/src/renderer/css/token.rs` file. The changes include adding a new `CssTokenizer` struct and its constructor method.

Key changes:

* [`saba_core/src/renderer/css/token.rs`](diffhunk://#diff-9f1847a277eee073547b9448e39e6349855a2d84490a5998987f235a29688125R2): Added the `alloc::vec::Vec` import to support the new struct.
* [`saba_core/src/renderer/css/token.rs`](diffhunk://#diff-9f1847a277eee073547b9448e39e6349855a2d84490a5998987f235a29688125R19-R33): Added the `CssTokenizer` struct with fields `pos` and `input`, and implemented a `new` method for initializing the struct with a given CSS string.