### PR TITLE
add css tokenizer iterator

### DIFF
--- a/saba_core/src/renderer/css/token.rs
+++ b/saba_core/src/renderer/css/token.rs
@@ -31,3 +31,33 @@ impl CssTokenizer {
         }
     }
 }
+
+impl Iterator for CssTokenizer {
+    type Item = CssToken;
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            if self.pos >= self.input.len() {
+                return None;
+            }
+            let c = self.input[self.pos];
+            let token = match c {
+                '(' => CssToken::OpenParenthesis,
+                ')' => CssToken::CloseParenthesis,
+                ',' => CssToken::Delim(','),
+                '.' => CssToken::Delim('.'),
+                ':' => CssToken::Colon,
+                '{' => CssToken::OpenCurly,
+                '}' => CssToken::CloseCurly,
+                ' ' | '\n' => {
+                    self.pos += 1;
+                    continue;
+                }
+                _ => {
+                    unimplemented!("char {} is not supported yes", c);
+                }
+            };
+            self.pos += 1;
+            return Some(token);
+        }
+    }
+}


### PR DESCRIPTION
This pull request introduces an implementation of the `Iterator` trait for the `CssTokenizer` struct in the `saba_core/src/renderer/css/token.rs` file. This change allows the `CssTokenizer` to iterate over CSS tokens, providing a more idiomatic way to process CSS input.

Key changes include:

* Implemented the `Iterator` trait for `CssTokenizer`, defining the `Item` type as `CssToken` and providing a `next` method to return the next token or `None` if the end of the input is reached.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new tokenization feature for CSS, enhancing the ability to parse and recognize CSS tokens.
  
- **Bug Fixes**
	- Improved handling of whitespace and unsupported characters during tokenization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->