### PR TITLE
add string token

### DIFF
--- a/saba_core/src/renderer/css/token.rs
+++ b/saba_core/src/renderer/css/token.rs
@@ -30,6 +30,21 @@ impl CssTokenizer {
             input: css.chars().collect(),
         }
     }
+    fn consume_string_token(&mut self) -> String {
+        let mut s = String::new();
+        loop {
+            if self.pos >= self.input.len() {
+                return s;
+            }
+            self.pos += 1;
+            let c = self.input[self.pos];
+            match c {
+                '"' | '\'' => break,
+                _ => s.push(c),
+            }
+        }
+        s
+    }
 }
 
 impl Iterator for CssTokenizer {
@@ -41,6 +56,10 @@ impl Iterator for CssTokenizer {
             }
             let c = self.input[self.pos];
             let token = match c {
+                '"' | '\'' => {
+                    let value = self.consume_string_token();
+                    CssToken::StringToken(value)
+                }
                 '(' => CssToken::OpenParenthesis,
                 ')' => CssToken::CloseParenthesis,
                 ',' => CssToken::Delim(','),


### PR DESCRIPTION
This pull request introduces a new method to handle string tokens in the `CssTokenizer` class within the `saba_core/src/renderer/css/token.rs` file. The most important changes include adding a method to consume string tokens and updating the token matching logic to utilize this new method.

Enhancements to `CssTokenizer`:

* [`saba_core/src/renderer/css/token.rs`](diffhunk://#diff-9f1847a277eee073547b9448e39e6349855a2d84490a5998987f235a29688125R33-R47): Added a new method `consume_string_token` to handle the consumption of string tokens.
* [`saba_core/src/renderer/css/token.rs`](diffhunk://#diff-9f1847a277eee073547b9448e39e6349855a2d84490a5998987f235a29688125R59-R62): Updated the `impl Iterator for CssTokenizer` to match string tokens and use the new `consume_string_token` method for creating `CssToken::StringToken` instances.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced CSS tokenizer to better handle string tokens, improving parsing accuracy.
  
- **Bug Fixes**
	- Adjusted control flow in the tokenizer to ensure proper handling of string delimiters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->