### PR TITLE
add numeric token

### DIFF
--- a/saba_core/src/renderer/css/token.rs
+++ b/saba_core/src/renderer/css/token.rs
@@ -45,6 +45,37 @@ impl CssTokenizer {
         }
         s
     }
+
+    fn consume_numeric_token(&mut self) -> f64 {
+        let mut num = 0f64;
+        let mut floating = false;
+        let mut floating_digit = 1f64;
+
+        loop {
+            if self.pos >= self.input.len() {
+                return num;
+            }
+            self.pos += 1;
+            let c = self.input[self.pos];
+            match c {
+                '0'..='9' => {
+                    if floating {
+                        floating_digit *= 1f64 / 10f64;
+                        num += (c.to_digit(10).unwrap() as f64) * floating_digit
+                    } else {
+                        num = num * 10.0 + (c.to_digit(10).unwrap() as f64);
+                    }
+                    self.pos += 1;
+                }
+                '.' => {
+                    floating = true;
+                    self.pos += 1;
+                }
+                _ => break,
+            }
+        }
+        num
+    }
 }
 
 impl Iterator for CssTokenizer {
@@ -59,6 +90,11 @@ impl Iterator for CssTokenizer {
                 '"' | '\'' => {
                     let value = self.consume_string_token();
                     CssToken::StringToken(value)
+                }
+                '0'..='9' => {
+                    let t = CssToken::Number(self.consume_numeric_token());
+                    self.pos -= 1;
+                    t
                 }
                 '(' => CssToken::OpenParenthesis,
                 ')' => CssToken::CloseParenthesis,


### PR DESCRIPTION
This pull request introduces enhancements to the `CssTokenizer` in the `saba_core/src/renderer/css/token.rs` file, specifically adding functionality to handle numeric tokens. The most important changes include the addition of a method to consume numeric tokens and the modification of the iterator implementation to utilize this new method.

Enhancements to numeric token handling:

* [`saba_core/src/renderer/css/token.rs`](diffhunk://#diff-9f1847a277eee073547b9448e39e6349855a2d84490a5998987f235a29688125R48-R78): Added the `consume_numeric_token` method to the `CssTokenizer` implementation to parse numeric values from the input.
* [`saba_core/src/renderer/css/token.rs`](diffhunk://#diff-9f1847a277eee073547b9448e39e6349855a2d84490a5998987f235a29688125R94-R98): Updated the `Iterator` implementation for `CssTokenizer` to recognize numeric characters and use the new `consume_numeric_token` method to create `Number` tokens.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced CSS token parsing to support numeric tokens, including both integer and floating-point representations. 
- **Bug Fixes**
	- Improved handling of character parsing to ensure accurate recognition of numeric values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->