### PR TITLE
add ident token

### DIFF
--- a/saba_core/src/renderer/css/token.rs
+++ b/saba_core/src/renderer/css/token.rs
@@ -76,6 +76,21 @@ impl CssTokenizer {
         }
         num
     }
+    fn consume_ident_token(&mut self) -> String {
+        let mut s = String::new();
+        s.push(self.input[self.pos]);
+        loop {
+            self.pos += 1;
+            let c = self.input[self.pos];
+            match c {
+                'a'..='z' | 'A'..='Z' | '0'..='9' | '-' | '_' => {
+                    s.push(c);
+                }
+                _ => break,
+            }
+        }
+        s
+    }
 }
 
 impl Iterator for CssTokenizer {
@@ -93,6 +108,34 @@ impl Iterator for CssTokenizer {
                 }
                 '0'..='9' => {
                     let t = CssToken::Number(self.consume_numeric_token());
+                    self.pos -= 1;
+                    t
+                }
+                '#' => {
+                    let value = self.consume_ident_token();
+                    self.pos -= 1;
+                    CssToken::HashToken(value)
+                }
+                '_' => {
+                    let t = CssToken::Ident(self.consume_ident_token());
+                    self.pos -= 1;
+                    t
+                }
+                '@' => {
+                    if self.input[self.pos + 1].is_ascii_alphabetic()
+                        && self.input[self.pos + 2].is_alphanumeric()
+                        && self.input[self.pos + 3].is_alphanumeric()
+                    {
+                        self.pos += 1;
+                        let t = CssToken::AtKeyword(self.consume_ident_token());
+                        self.pos -= 1;
+                        t
+                    } else {
+                        CssToken::Delim('@')
+                    }
+                }
+                'a'..='z' | 'A'..='Z' => {
+                    let t = CssToken::Ident(self.consume_ident_token());
                     self.pos -= 1;
                     t
                 }


### PR DESCRIPTION
This pull request introduces enhancements to the `CssTokenizer` in the `saba_core/src/renderer/css/token.rs` file. The key changes include the addition of a method to consume identifier tokens and modifications to the `Iterator` implementation to handle new token types.

### Enhancements to `CssTokenizer`:

* Added a new method `consume_ident_token` to the `CssTokenizer` to process and return identifier tokens.

### Modifications to `Iterator` implementation:

* Updated the `Iterator` implementation for `CssTokenizer` to handle `#`, `_`, `@`, and alphabetic characters by utilizing the new `consume_ident_token` method and returning appropriate token types (`HashToken`, `Ident`, `AtKeyword`, `Delim`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced CSS tokenizer functionality to recognize and process identifiers and hash tokens more effectively.
- **Bug Fixes**
	- Improved handling of alphabetic characters in identifiers, now supporting both uppercase and lowercase letters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->