### PR TITLE
add empty token test

### DIFF
--- a/saba_core/src/renderer/css/token.rs
+++ b/saba_core/src/renderer/css/token.rs
@@ -159,3 +159,15 @@ impl Iterator for CssTokenizer {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::string::ToString;
+    #[test]
+    fn test_empty() {
+        let style = "".to_string();
+        let mut t = CssTokenizer::new(style);
+        assert!(t.next().is_none());
+    }
+}


### PR DESCRIPTION
This pull request includes the addition of a test module to the `CssTokenizer` implementation in the `saba_core/src/renderer/css/token.rs` file. The new test module aims to ensure the tokenizer handles an empty string correctly.

Testing improvements:

* Added a test module with a test case `test_empty` to verify that the `CssTokenizer` correctly returns `None` when initialized with an empty string. (`[saba_core/src/renderer/css/token.rsR162-R173](diffhunk://#diff-9f1847a277eee073547b9448e39e6349855a2d84490a5998987f235a29688125R162-R173)`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
	- Introduced a new test module for the CSS tokenizer.
	- Added a test to verify behavior with empty input, ensuring no tokens are produced.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->