### PR TITLE
add css one token test

### DIFF
--- a/saba_core/src/renderer/css/token.rs
+++ b/saba_core/src/renderer/css/token.rs
@@ -144,6 +144,7 @@ impl Iterator for CssTokenizer {
                 ',' => CssToken::Delim(','),
                 '.' => CssToken::Delim('.'),
                 ':' => CssToken::Colon,
+                ';' => CssToken::SemiColon,
                 '{' => CssToken::OpenCurly,
                 '}' => CssToken::CloseCurly,
                 ' ' | '\n' => {
@@ -168,6 +169,24 @@ mod tests {
     fn test_empty() {
         let style = "".to_string();
         let mut t = CssTokenizer::new(style);
+        assert!(t.next().is_none());
+    }
+    #[test]
+    fn test_one_rule() {
+        let style = "p { color: red; }".to_string();
+        let mut t = CssTokenizer::new(style);
+        let expected = [
+            CssToken::Ident("p".to_string()),
+            CssToken::OpenCurly,
+            CssToken::Ident("color".to_string()),
+            CssToken::Colon,
+            CssToken::Ident("red".to_string()),
+            CssToken::SemiColon,
+            CssToken::CloseCurly,
+        ];
+        for e in expected {
+            assert_eq!(Some(e.clone()), t.next());
+        }
         assert!(t.next().is_none());
     }
 }


### PR DESCRIPTION
This pull request includes changes to the `saba_core/src/renderer/css/token.rs` file to enhance the CSS tokenization process by adding support for semicolons and introducing a new test case.

Enhancements to CSS tokenization:

* Added support for the semicolon (`;`) token in the `Iterator` implementation for `CssTokenizer`.

Testing improvements:

* Introduced a new test case `test_one_rule` to verify the correct tokenization of a simple CSS rule containing a semicolon.