### PR TITLE
add css id selector test

### DIFF
--- a/saba_core/src/renderer/css/token.rs
+++ b/saba_core/src/renderer/css/token.rs
@@ -189,4 +189,22 @@ mod tests {
         }
         assert!(t.next().is_none());
     }
+    #[test]
+    fn test_id_selector() {
+        let style = "#id { color: red; }".to_string();
+        let mut t = CssTokenizer::new(style);
+        let expected = [
+            CssToken::HashToken("#id".to_string()),
+            CssToken::OpenCurly,
+            CssToken::Ident("color".to_string()),
+            CssToken::Colon,
+            CssToken::Ident("red".to_string()),
+            CssToken::SemiColon,
+            CssToken::CloseCurly,
+        ];
+        for e in expected {
+            assert_eq!(Some(e.clone()), t.next());
+        }
+        assert!(t.next().is_none());
+    }
 }


### PR DESCRIPTION
This pull request includes a new test case added to the `saba_core/src/renderer/css/token.rs` file to ensure the correct tokenization of CSS ID selectors.

Testing improvements:

* Added a new test function `test_id_selector` to verify that the `CssTokenizer` correctly tokenizes a CSS ID selector and its associated style properties.