### PR TITLE
add css class selector test

### DIFF
--- a/saba_core/src/renderer/css/token.rs
+++ b/saba_core/src/renderer/css/token.rs
@@ -207,4 +207,23 @@ mod tests {
         }
         assert!(t.next().is_none());
     }
+    #[test]
+    fn test_class_selector() {
+        let style = ".class { color: red; }".to_string();
+        let mut t = CssTokenizer::new(style);
+        let expected = [
+            CssToken::Delim('.'),
+            CssToken::Ident("class".to_string()),
+            CssToken::OpenCurly,
+            CssToken::Ident("color".to_string()),
+            CssToken::Colon,
+            CssToken::Ident("red".to_string()),
+            CssToken::SemiColon,
+            CssToken::CloseCurly,
+        ];
+        for e in expected {
+            assert_eq!(Some(e.clone()), t.next());
+        }
+        assert!(t.next().is_none());
+    }
 }


### PR DESCRIPTION
This pull request includes a new test case for the CSS tokenizer in the `saba_core` module. The test case ensures that the tokenizer correctly handles class selectors.

Testing improvements:

* Added a new test case `test_class_selector` to the `mod tests` section in `saba_core/src/renderer/css/token.rs`. This test verifies that the tokenizer correctly processes a CSS class selector and its associated style rules.