### PR TITLE
add css multiple rule test

### DIFF
--- a/saba_core/src/renderer/css/token.rs
+++ b/saba_core/src/renderer/css/token.rs
@@ -55,7 +55,7 @@ impl CssTokenizer {
             if self.pos >= self.input.len() {
                 return num;
             }
-            self.pos += 1;
+
             let c = self.input[self.pos];
             match c {
                 '0'..='9' => {
@@ -218,6 +218,35 @@ mod tests {
             CssToken::Ident("color".to_string()),
             CssToken::Colon,
             CssToken::Ident("red".to_string()),
+            CssToken::SemiColon,
+            CssToken::CloseCurly,
+        ];
+        for e in expected {
+            assert_eq!(Some(e.clone()), t.next());
+        }
+        assert!(t.next().is_none());
+    }
+    #[test]
+    fn test_multiple_rules() {
+        let style = "p { content: \"Hey\";} h1 { font-size: 40; color: blue; }".to_string();
+        let mut t = CssTokenizer::new(style);
+        let expected = [
+            CssToken::Ident("p".to_string()),
+            CssToken::OpenCurly,
+            CssToken::Ident("content".to_string()),
+            CssToken::Colon,
+            CssToken::StringToken("Hey".to_string()),
+            CssToken::SemiColon,
+            CssToken::CloseCurly,
+            CssToken::Ident("h1".to_string()),
+            CssToken::OpenCurly,
+            CssToken::Ident("font-size".to_string()),
+            CssToken::Colon,
+            CssToken::Number(40.0),
+            CssToken::SemiColon,
+            CssToken::Ident("color".to_string()),
+            CssToken::Colon,
+            CssToken::Ident("blue".to_string()),
             CssToken::SemiColon,
             CssToken::CloseCurly,
         ];


### PR DESCRIPTION
This pull request includes a minor change to the `CssTokenizer` implementation and adds a new test case to the `tests` module in the `saba_core/src/renderer/css/token.rs` file.

Codebase simplification:

* [`saba_core/src/renderer/css/token.rs`](diffhunk://#diff-9f1847a277eee073547b9448e39e6349855a2d84490a5998987f235a29688125L58-R58): Removed an unnecessary increment operation from the `CssTokenizer` implementation.

Testing improvements:

* [`saba_core/src/renderer/css/token.rs`](diffhunk://#diff-9f1847a277eee073547b9448e39e6349855a2d84490a5998987f235a29688125R229-R257): Added a new test case `test_multiple_rules` to verify the correct tokenization of multiple CSS rules.