### PR TITLE
add display type

### DIFF
--- a/saba_core/src/renderer/layout/computed_style.rs
+++ b/saba_core/src/renderer/layout/computed_style.rs
@@ -15,6 +15,33 @@ pub enum DisplayType {
     None,
 }
 
+impl DisplayType {
+    fn default(node: &Rc<RefCell<Node>>) -> Self {
+        match &node.borrow().kind() {
+            NodeKind::Document => DisplayType::Block,
+            NodeKind::Element(e) => {
+                if e.is_block_element() {
+                    DisplayType::Block
+                } else {
+                    DisplayType::Inline
+                }
+            }
+            NodeKind::Text(_) => DisplayType::Inline,
+        }
+    }
+    pub fn from_str_display(s: &str) -> Result<Self, Error> {
+        match s {
+            "block" => Ok(Self::Block),
+            "inline" => Ok(Self::Inline),
+            "none" => Ok(Self::None),
+            _ => Err(Error::UnexpectedInput(format!(
+                "display type {:?} is not supported yet",
+                s
+            ))),
+        }
+    }
+}
+
 // 2. TextDecorationの定義を追加
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub enum TextDecoration {
@@ -98,6 +125,11 @@ impl ComputedStyle {
     pub fn display(&self) -> DisplayType {
         self.display
             .expect("failed to access Css property: display")
+    }
+
+    pub fn set_display_type_default(&mut self, node: &Rc<RefCell<Node>>) {
+        let display_type = DisplayType::default(node);
+        self.display = Some(display_type);
     }
 
     pub fn font_size(&self) -> FontSize {


### PR DESCRIPTION
This pull request introduces enhancements to the `DisplayType` enum and the `ComputedStyle` struct in the `saba_core` library. The changes include adding methods to determine the default display type based on node type and converting string representations to `DisplayType` values, as well as a method to set the default display type in `ComputedStyle`.

Enhancements to `DisplayType` enum:

* Added a `default` method to determine the display type based on the node type (`NodeKind::Document`, `NodeKind::Element`, or `NodeKind::Text`).
* Added a `from_str_display` method to convert string representations ("block", "inline", "none") to `DisplayType` values, returning an error for unsupported values.

Enhancements to `ComputedStyle` struct:

* Added a `set_display_type_default` method to set the display type of a node to its default value using the `DisplayType::default` method.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced display type handling for nodes, allowing automatic determination of display properties.
	- Introduced methods to convert string representations of display types into enum values.
	- Added functionality to set display types based on node types in computed styles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->