### PR TITLE
add text decoration

### DIFF
--- a/saba_core/src/renderer/layout/computed_style.rs
+++ b/saba_core/src/renderer/layout/computed_style.rs
@@ -48,6 +48,17 @@ pub enum TextDecoration {
     None,
     Underline,
 }
+impl TextDecoration {
+    fn default(node: &Rc<RefCell<Node>>) -> Self {
+        match &node.borrow().kind() {
+            NodeKind::Element(element) => match element.kind() {
+                ElementKind::A => TextDecoration::Underline,
+                _ => TextDecoration::None,
+            },
+            _ => TextDecoration::None,
+        }
+    }
+}
 
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub enum FontSize {
@@ -143,6 +154,12 @@ impl ComputedStyle {
     pub fn text_decoration(&self) -> TextDecoration {
         self.text_decoration
             .expect("failed to access Css property: text_decoration")
+    }
+
+    pub fn set_text_decoration_default(&mut self, node: &Rc<RefCell<Node>>) -> TextDecoration {
+        let text_decoration = TextDecoration::default(node);
+        self.text_decoration = Some(text_decoration);
+        text_decoration
     }
 
     pub fn set_height(&mut self, height: i64) {


### PR DESCRIPTION
This pull request introduces a new method for setting default text decorations based on node types in the `saba_core` renderer layout. The changes primarily involve adding a new method to the `TextDecoration` enum and updating the `ComputedStyle` implementation to utilize this new method.

### Enhancements to text decoration handling:

* [`saba_core/src/renderer/layout/computed_style.rs`](diffhunk://#diff-f83379c8ac1b6d07116dbb17a1500d42b45e6c93ad49b7cb6355dd64306877d6R51-R61): Added a `default` method to the `TextDecoration` enum to determine the default decoration based on the node type, specifically setting `Underline` for `ElementKind::A` and `None` otherwise.
* [`saba_core/src/renderer/layout/computed_style.rs`](diffhunk://#diff-f83379c8ac1b6d07116dbb17a1500d42b45e6c93ad49b7cb6355dd64306877d6R159-R164): Added a `set_text_decoration_default` method to the `ComputedStyle` implementation to apply the default text decoration to a node and update the `text_decoration` property accordingly.