### PR TITLE
add partial EQ

### DIFF
--- a/saba_core/src/renderer/layout/layout_object.rs
+++ b/saba_core/src/renderer/layout/layout_object.rs
@@ -301,6 +301,12 @@ impl LayoutObject {
     }
 }
 
+impl PartialEq for LayoutObject {
+    fn eq(&self, other: &Self) -> bool {
+        self.node == other.node
+    }
+}
+
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum LayoutObjectKind {
     Block,


### PR DESCRIPTION
This pull request introduces an implementation of the `PartialEq` trait for the `LayoutObject` struct in the `saba_core/src/renderer/layout/layout_object.rs` file. This change allows for the comparison of `LayoutObject` instances based on their `node` field.

Key changes:

* Implemented the `PartialEq` trait for the `LayoutObject` struct to enable equality comparison based on the `node` field.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced equality comparisons for layout objects, enabling better management of layout collections and duplicate checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->