### PR TITLE
add empty layoutview test

### DIFF
--- a/saba_core/src/renderer/dom/api.rs
+++ b/saba_core/src/renderer/dom/api.rs
@@ -3,6 +3,7 @@ use crate::renderer::dom::node::ElementKind;
 use crate::renderer::dom::node::Node;
 use crate::renderer::dom::node::NodeKind;
 use alloc::rc::Rc;
+use alloc::string::String;
 use alloc::string::ToString;
 use alloc::vec::Vec;
 use core::cell::RefCell;
@@ -31,4 +32,20 @@ pub fn get_target_element_node(
         }
         None => None,
     }
+}
+
+pub fn get_style_content(root: Rc<RefCell<Node>>) -> String {
+    let style_node = match get_target_element_node(Some(root), ElementKind::Style) {
+        Some(node) => node,
+        None => return "".to_string(),
+    };
+    let text_node = match style_node.borrow().first_child() {
+        Some(node) => node,
+        None => return "".to_string(),
+    };
+    let content = match &text_node.borrow().kind() {
+        NodeKind::Text(ref s) => s.clone(),
+        _ => "".to_string(),
+    };
+    content
 }

--- a/saba_core/src/renderer/layout/layout_view.rs
+++ b/saba_core/src/renderer/layout/layout_view.rs
@@ -164,3 +164,35 @@ fn build_layout_tree(
     }
     layout_object
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::alloc::string::String;
+    use crate::alloc::string::ToString;
+    use crate::renderer::css::cssom::CssParser;
+    use crate::renderer::css::token::CssTokenizer;
+    use crate::renderer::dom::api::get_style_content;
+    // use crate::renderer::dom::node::Element;
+    // use crate::renderer::dom::node::Node;
+    // use crate::renderer::dom::node::NodeKind;
+    use crate::renderer::html::parser::HtmlParser;
+    use crate::renderer::html::token::HtmlTokenizer;
+    // use alloc::vec::Vec;
+
+    fn create_layout_view(html: String) -> LayoutView {
+        let t = HtmlTokenizer::new(html);
+        let windows = HtmlParser::new(t).construct_tree();
+        let dom = windows.borrow().document();
+        let style = get_style_content(dom.clone());
+        let css_tokenizer = CssTokenizer::new(style);
+        let cssom = CssParser::new(css_tokenizer).parse_stylesheet();
+        LayoutView::new(dom, &cssom)
+    }
+
+    #[test]
+    fn test_empty() {
+        let layout_view = create_layout_view("".to_string());
+        assert_eq!(layout_view.root(), None);
+    }
+}


### PR DESCRIPTION
This pull request introduces several changes to the `saba_core` crate, focusing on enhancing the DOM API and adding tests for the layout view. The most important changes include adding a new function to retrieve style content, importing necessary modules, and creating a test module for layout view.

Enhancements to DOM API:

* [`saba_core/src/renderer/dom/api.rs`](diffhunk://#diff-1396e88008c26540ab0dfde1ea2709dfe0322d0616ad36b54f5edc1a2fe0b7d4R36-R51): Added a new function `get_style_content` to retrieve the content of the style element.
* [`saba_core/src/renderer/dom/api.rs`](diffhunk://#diff-1396e88008c26540ab0dfde1ea2709dfe0322d0616ad36b54f5edc1a2fe0b7d4R6): Imported `alloc::string::String` to support string operations.

Testing improvements:

* [`saba_core/src/renderer/layout/layout_view.rs`](diffhunk://#diff-c7f6f257e4dd472c691cd49539cce57d6a0e01445d636758a5321412993fddb9R167-R198): Added a test module with a function `create_layout_view` to create a layout view from HTML content and a test `test_empty` to verify the creation of an empty layout view.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a function to retrieve style content from a node.
	- Added functionality to create a `LayoutView` from an HTML string.

- **Bug Fixes**
	- Implemented a test to ensure correct handling of empty HTML input in `LayoutView`.

- **Tests**
	- Added new test cases to enhance testing coverage for layout functionalities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->