### PR TITLE
add body layoutview test

### DIFF
--- a/saba_core/src/renderer/layout/layout_view.rs
+++ b/saba_core/src/renderer/layout/layout_view.rs
@@ -173,12 +173,12 @@ mod tests {
     use crate::renderer::css::cssom::CssParser;
     use crate::renderer::css::token::CssTokenizer;
     use crate::renderer::dom::api::get_style_content;
-    // use crate::renderer::dom::node::Element;
+    use crate::renderer::dom::node::Element;
     // use crate::renderer::dom::node::Node;
-    // use crate::renderer::dom::node::NodeKind;
+    use crate::renderer::dom::node::NodeKind;
     use crate::renderer::html::parser::HtmlParser;
     use crate::renderer::html::token::HtmlTokenizer;
-    // use alloc::vec::Vec;
+    use alloc::vec::Vec;
 
     fn create_layout_view(html: String) -> LayoutView {
         let t = HtmlTokenizer::new(html);
@@ -194,5 +194,24 @@ mod tests {
     fn test_empty() {
         let layout_view = create_layout_view("".to_string());
         assert_eq!(layout_view.root(), None);
+    }
+    #[test]
+    fn test_body() {
+        let html = "<html><head></head><body></body></html>".to_string();
+        let layout_view = create_layout_view(html);
+
+        let root = layout_view.root();
+        assert!(root.is_some());
+        assert_eq!(
+            LayoutObjectKind::Block,
+            root.clone().expect("root should exist").borrow().kind()
+        );
+        assert_eq!(
+            NodeKind::Element(Element::new("body", Vec::new())),
+            root.clone()
+                .expect("root should exist")
+                .borrow()
+                .node_kind()
+        );
     }
 }


### PR DESCRIPTION
This pull request includes changes to the `saba_core/src/renderer/layout/layout_view.rs` file, focusing on cleaning up imports and adding a new test case.

Code cleanup:

* Un-commented and added necessary imports for `Element`, `NodeKind`, and `Vec` in the `mod tests` section.

Testing improvements:

* Added a new test case `test_body` to verify the creation of a layout view with a simple HTML structure and ensure the root node's kind and node type are correctly set.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
	- Introduced a new test to validate the behavior of the layout view with a basic HTML structure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->