### PR TITLE
add text layoutview test

### DIFF
--- a/saba_core/src/renderer/layout/layout_view.rs
+++ b/saba_core/src/renderer/layout/layout_view.rs
@@ -214,4 +214,40 @@ mod tests {
                 .node_kind()
         );
     }
+    #[test]
+    fn test_text() {
+        let html = "<html><head></head><body>text</body></html>".to_string();
+        let layout_view = create_layout_view(html);
+        let root = layout_view.root();
+        assert!(root.is_some());
+        assert_eq!(
+            LayoutObjectKind::Block,
+            root.clone().expect("root should exist").borrow().kind()
+        );
+        assert_eq!(
+            NodeKind::Element(Element::new("body", Vec::new())),
+            root.clone()
+                .expect("root should exist")
+                .borrow()
+                .node_kind()
+        );
+
+        let text = root.expect("root should exist").borrow().first_child();
+        assert!(text.is_some());
+        assert_eq!(
+            LayoutObjectKind::Text,
+            text.clone().expect("text should exist").borrow().kind()
+        );
+        assert_eq!(
+            LayoutObjectKind::Text,
+            text.clone().expect("text should exist").borrow().kind()
+        );
+        assert_eq!(
+            NodeKind::Text("text".to_string()),
+            text.clone()
+                .expect("text should exist")
+                .borrow()
+                .node_kind()
+        );
+    }
 }


### PR DESCRIPTION
This pull request includes a new test for the `layout_view` functionality in the `saba_core` module. The most important change is the addition of a test to ensure proper handling and rendering of text nodes in the layout view.

Testing improvements:

* [`saba_core/src/renderer/layout/layout_view.rs`](diffhunk://#diff-c7f6f257e4dd472c691cd49539cce57d6a0e01445d636758a5321412993fddb9R217-R252): Added a new test function `test_text` to verify that the `layout_view` correctly handles and renders text nodes within the HTML structure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
	- Added a new test case to verify text node processing in the layout view
	- Improved test coverage for layout rendering functionality
<!-- end of auto-generated comment: release notes by coderabbit.ai -->