### PR TITLE
add display none layoutview test

### DIFF
--- a/saba_core/src/renderer/layout/layout_view.rs
+++ b/saba_core/src/renderer/layout/layout_view.rs
@@ -250,4 +250,11 @@ mod tests {
                 .node_kind()
         );
     }
+    #[test]
+    fn test_display_none() {
+        let html = "<html><head><style>body{display: none;}</style></head><body>text</body></html>"
+            .to_string();
+        let layout_view = create_layout_view(html);
+        assert_eq!(None, layout_view.root());
+    }
 }


### PR DESCRIPTION
This pull request includes a new test case added to the `mod tests` section of the `saba_core/src/renderer/layout/layout_view.rs` file. The test case verifies that an HTML element with `display: none` is correctly handled by the `layout_view` function.

Testing:

* [`saba_core/src/renderer/layout/layout_view.rs`](diffhunk://#diff-c7f6f257e4dd472c691cd49539cce57d6a0e01445d636758a5321412993fddb9R253-R259): Added a new test case `test_display_none` to ensure that elements with `display: none` are not included in the layout view.