### PR TITLE
add paint method

### DIFF
--- a/saba_core/src/display_item.rs
+++ b/saba_core/src/display_item.rs
@@ -1,0 +1,47 @@
+use crate::renderer::layout::computed_style::ComputedStyle;
+use crate::renderer::layout::layout_object::LayoutPoint;
+use crate::renderer::layout::layout_object::LayoutSize;
+use alloc::string::String;
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum DisplayItem {
+    Rect {
+        style: ComputedStyle,
+        layout_point: LayoutPoint,
+        layout_size: LayoutSize,
+    },
+    Text {
+        style: ComputedStyle,
+        layout_point: LayoutPoint,
+        text: String,
+    },
+    Img {
+        src: String,
+        style: ComputedStyle,
+        layout_point: LayoutPoint,
+    },
+}
+
+impl DisplayItem {
+    pub fn is_rect(&self) -> bool {
+        matches!(
+            self,
+            DisplayItem::Rect {
+                style: _,
+                layout_point: _,
+                layout_size: _,
+            }
+        )
+    }
+
+    pub fn is_text(&self) -> bool {
+        matches!(
+            self,
+            DisplayItem::Text {
+                text: _,
+                style: _,
+                layout_point: _,
+            }
+        )
+    }
+}

--- a/saba_core/src/lib.rs
+++ b/saba_core/src/lib.rs
@@ -4,6 +4,7 @@ extern crate alloc;
 
 pub mod browser;
 pub mod constants;
+pub mod display_item;
 pub mod error;
 pub mod http;
 pub mod renderer;

--- a/saba_core/src/renderer/layout/layout_object.rs
+++ b/saba_core/src/renderer/layout/layout_object.rs
@@ -3,6 +3,9 @@ use crate::constants::CHAR_HEIGHT;
 use crate::constants::CHAR_HEIGHT_WITH_PADDING;
 use crate::constants::CHAR_WIDTH;
 use crate::constants::CONTENT_AREA_WIDTH;
+use crate::constants::WINDOW_PADDING;
+use crate::constants::WINDOW_WIDTH;
+use crate::display_item::DisplayItem;
 use crate::renderer::css::cssom::ComponentValue;
 use crate::renderer::css::cssom::Declaration;
 use crate::renderer::css::cssom::Selector;
@@ -15,8 +18,36 @@ use crate::renderer::layout::computed_style::DisplayType;
 use crate::renderer::layout::computed_style::FontSize;
 use alloc::rc::Rc;
 use alloc::rc::Weak;
+use alloc::string::String;
+use alloc::vec;
 use alloc::vec::Vec;
 use core::cell::RefCell;
+
+/// This is used when { word-break: normal; } in CSS.
+/// https://drafts.csswg.org/css-text/#word-break-property
+fn find_index_for_line_break(line: String, max_index: usize) -> usize {
+    for i in (0..max_index).rev() {
+        if line.chars().collect::<Vec<char>>()[i] == ' ' {
+            return i;
+        }
+    }
+    max_index
+}
+/// https://drafts.csswg.org/css-text/#word-break-property
+fn split_text(line: String, char_width: i64) -> Vec<String> {
+    let mut result: Vec<String> = vec![];
+    if line.len() as i64 * char_width > (WINDOW_WIDTH + WINDOW_PADDING) {
+        let s = line.split_at(find_index_for_line_break(
+            line.clone(),
+            ((WINDOW_WIDTH + WINDOW_PADDING) / char_width) as usize,
+        ));
+        result.push(s.0.to_string());
+        result.extend(split_text(s.1.trim().to_string(), char_width))
+    } else {
+        result.push(line);
+    }
+    result
+}
 
 #[derive(Debug, Clone)]
 pub struct LayoutObject {
@@ -142,6 +173,57 @@ impl LayoutObject {
         self.size = size;
     }
 
+    pub fn paint(&mut self) -> Vec<DisplayItem> {
+        if self.style.display() == DisplayType::DisplayNone {
+            return vec![];
+        }
+
+        match self.kind {
+            LayoutObjectKind::Block => {
+                if let NodeKind::Element(_e) = self.node_kind() {
+                    return vec![DisplayItem::Rect {
+                        style: self.style(),
+                        layout_point: self.point(),
+                        layout_size: self.size(),
+                    }];
+                }
+            }
+            LayoutObjectKind::Inline => {}
+            LayoutObjectKind::Text => {
+                if let NodeKind::Text(t) = self.node_kind() {
+                    let mut v = vec![];
+
+                    let ratio = match self.style.font_size() {
+                        FontSize::Medium => 1,
+                        FontSize::XLarge => 2,
+                        FontSize::XXLarge => 3,
+                    };
+                    let plain_text = t
+                        .replace('\n', " ")
+                        .split(' ')
+                        .filter(|s| !s.is_empty())
+                        .collect::<Vec<_>>()
+                        .join(" ");
+                    let lines = split_text(plain_text, CHAR_WIDTH * ratio);
+                    for (i, line) in lines.into_iter().enumerate() {
+                        let item = DisplayItem::Text {
+                            text: line,
+                            style: self.style(),
+                            layout_point: LayoutPoint::new(
+                                self.point().x(),
+                                self.point().y() + CHAR_HEIGHT_WITH_PADDING * i as i64,
+                            ),
+                        };
+                        v.push(item);
+                    }
+
+                    return v;
+                }
+            }
+        }
+
+        vec![]
+    }
     pub fn update_kind(&mut self) {
         match self.node_kind() {
             NodeKind::Document => panic!("should not craete a layout object for a Document node"),

--- a/saba_core/src/renderer/layout/layout_view.rs
+++ b/saba_core/src/renderer/layout/layout_view.rs
@@ -1,4 +1,5 @@
 use crate::constants::CONTENT_AREA_WIDTH;
+use crate::display_item::DisplayItem;
 use crate::renderer::css::cssom::StyleSheet;
 use crate::renderer::dom::api::get_target_element_node;
 use crate::renderer::dom::node::ElementKind;
@@ -9,6 +10,7 @@ use crate::renderer::layout::layout_object::LayoutObjectKind;
 use crate::renderer::layout::layout_object::LayoutPoint;
 use crate::renderer::layout::layout_object::LayoutSize;
 use alloc::rc::Rc;
+use alloc::vec::Vec;
 use core::cell::RefCell;
 
 #[derive(Debug, Clone)]
@@ -25,6 +27,24 @@ impl LayoutView {
         };
         tree.update_layout();
         tree
+    }
+
+    fn paint_node(node: &Option<Rc<RefCell<LayoutObject>>>, display_items: &mut Vec<DisplayItem>) {
+        match node {
+            Some(n) => {
+                display_items.extend(n.borrow_mut().paint());
+                let first_child = n.borrow().first_child();
+                Self::paint_node(&first_child, display_items);
+                let next_sibling = n.borrow().next_sibling();
+                Self::paint_node(&next_sibling, display_items);
+            }
+            None => (),
+        }
+    }
+    pub fn paint(&self) -> Vec<DisplayItem> {
+        let mut display_items = Vec::new();
+        Self::paint_node(&self.root, &mut display_items);
+        display_items
     }
 
     fn calculate_node_position(


### PR DESCRIPTION
This pull request introduces a new `DisplayItem` enum and integrates its usage across various modules in the `saba_core` project. The changes include adding the `DisplayItem` enum, updating the layout object to use this new enum, and adding functionality to paint layout objects.

Key changes include:

### Introduction of `DisplayItem` Enum:

* [`saba_core/src/display_item.rs`](diffhunk://#diff-c59e7ada126de11bf745c8c575039900abb45e852c99c62a3460e3beacb584b0R1-R47): Added the `DisplayItem` enum with variants for `Rect`, `Text`, and `Img`, along with methods to check the type of display item.

### Integration of `DisplayItem`:

* [`saba_core/src/lib.rs`](diffhunk://#diff-a7b2c291dc420c0fa75a606e057c83a36ad3150a165f63a24ae888624364d783R7): Added `display_item` module to the crate.
* `saba_core/src/renderer/layout/layout_object.rs`: 
  * Imported `DisplayItem` and additional constants.
  * Added `split_text` function for handling text wrapping.
  * Updated `LayoutObject` struct with a `paint` method to generate `DisplayItem` instances based on the layout object type. [[1]](diffhunk://#diff-c36dc9d5a2b2b04081c943f5d3d115b09f7d0a45ed881a976a64bbda65d0506eR6-R8) [[2]](diffhunk://#diff-c36dc9d5a2b2b04081c943f5d3d115b09f7d0a45ed881a976a64bbda65d0506eR21-R51) [[3]](diffhunk://#diff-c36dc9d5a2b2b04081c943f5d3d115b09f7d0a45ed881a976a64bbda65d0506eR176-R226)

### Painting Layout Objects:

* `saba_core/src/renderer/layout/layout_view.rs`: 
  * Imported `DisplayItem`.
  * Added `paint_node` and `paint` methods to the `LayoutView` struct to traverse the layout tree and collect `DisplayItem` instances. [[1]](diffhunk://#diff-c7f6f257e4dd472c691cd49539cce57d6a0e01445d636758a5321412993fddb9R2) [[2]](diffhunk://#diff-c7f6f257e4dd472c691cd49539cce57d6a0e01445d636758a5321412993fddb9R13) [[3]](diffhunk://#diff-c7f6f257e4dd472c691cd49539cce57d6a0e01445d636758a5321412993fddb9R32-R49)