### PR TITLE
add page attributes

### DIFF
--- a/saba_core/src/renderer/page.rs
+++ b/saba_core/src/renderer/page.rs
@@ -6,15 +6,22 @@ use alloc::rc::Rc;
 use alloc::rc::Weak;
 use core::cell::RefCell;
 
+use crate::display_item::DisplayItem;
+use crate::renderer::css::cssom::StyleSheet;
 use crate::renderer::html::parser::HtmlParser;
 use crate::renderer::html::token::HtmlTokenizer;
+use crate::renderer::layout::layout_view::LayoutView;
 use crate::utils::convert_dom_to_string;
 use alloc::string::String;
+use alloc::vec::Vec;
 
 #[derive(Debug, Clone)]
 pub struct Page {
     browser: Weak<RefCell<Browser>>,
     frame: Option<Rc<RefCell<Window>>>,
+    style: Option<StyleSheet>,
+    layout_view: Option<LayoutView>,
+    display_items: Vec<DisplayItem>,
 }
 
 impl Page {
@@ -22,6 +29,9 @@ impl Page {
         Self {
             browser: Weak::new(),
             frame: None,
+            style: None,
+            layout_view: None,
+            display_items: Vec::new(),
         }
     }
 
@@ -31,6 +41,18 @@ impl Page {
 
     pub fn set_frame(&mut self, frame: Rc<RefCell<Window>>) {
         self.frame = Some(frame);
+    }
+
+    pub fn set_style(&mut self, style: StyleSheet) {
+        self.style = Some(style);
+    }
+
+    pub fn set_layout_view(&mut self, layout_view: LayoutView) {
+        self.layout_view = Some(layout_view);
+    }
+
+    pub fn set_display_items(&mut self, display_items: Vec<DisplayItem>) {
+        self.display_items = display_items;
     }
 
     pub fn receive_response(&mut self, response: HttpResponse) -> String {


### PR DESCRIPTION
This pull request includes changes to the `saba_core/src/renderer/page.rs` file to enhance the `Page` struct by adding new fields and corresponding setter methods. These changes are aimed at improving the rendering capabilities of the `Page` struct.

Enhancements to `Page` struct:

* Added new fields `style`, `layout_view`, and `display_items` to the `Page` struct to store additional rendering information.
* Implemented setter methods `set_style`, `set_layout_view`, and `set_display_items` to allow updating the new fields in the `Page` struct.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced `Page` struct with new capabilities for managing styles, layout views, and display items
	- Added methods to set style, layout view, and display items dynamically
<!-- end of auto-generated comment: release notes by coderabbit.ai -->