### PR TITLE
add coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,20 +49,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with:
-          submodules: true
 
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: stable
-          components: rustfmt, clippy
+      - name: Update Rust to latest stable
+        run: |
+          rustup update stable
+          rustup default stable
+          rustc --version  # バージョン確認
 
       - name: Install Tarpaulin
         run: cargo install cargo-tarpaulin
 
       - name: Run Tarpaulin
         run: cargo tarpaulin --out Xml
+
 
   docker:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,8 +54,15 @@ jobs:
         run: cargo install cargo-tarpaulin  --locked
 
       - name: Run Tarpaulin
-        run: cargo tarpaulin --workspace --out Xml
+        run: cargo tarpaulin --workspace --out Xml --out Html
 
+      - name: Upload coverage reports
+        uses: actions/upload-artifact@v3
+        with:
+          name: code-coverage-report
+          path: |
+            cobertura.xml
+            tarpaulin-report.html
 
   docker:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,14 +50,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Update Rust to latest stable
+      - name: Force stable override in CI
         run: |
-          rustup update stable
-          rustup default stable
-          rustc --version  # バージョン確認
+          rustup override set stable
+          rustc --version
 
       - name: Install Tarpaulin
-        run: cargo install cargo-tarpaulin --locked
+        run: cargo install cargo-tarpaulin
 
       - name: Run Tarpaulin
         run: cargo tarpaulin --out Xml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
           rustc --version  # バージョン確認
 
       - name: Install Tarpaulin
-        run: cargo install cargo-tarpaulin
+        run: cargo install cargo-tarpaulin --locked
 
       - name: Run Tarpaulin
         run: cargo tarpaulin --out Xml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,16 +50,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Force stable override in CI
-        run: |
-          rustup override set stable
-          rustc --version
-
       - name: Install Tarpaulin
-        run: cargo install cargo-tarpaulin
+        run: cargo install cargo-tarpaulin  --locked
 
       - name: Run Tarpaulin
-        run: cargo tarpaulin --out Xml
+        run: cargo tarpaulin --workspace --out Xml
 
 
   docker:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,25 @@ jobs:
       - name: Run tests
         run: cargo test --workspace
 
+  rust-coverage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: nightly-2024-01-01
+          components: rustfmt, clippy
+
+      - name: Install Tarpaulin
+        run: cargo install cargo-tarpaulin
+
+      - name: Run Tarpaulin
+        run: cargo tarpaulin --out Xml
+
   docker:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly-2024-01-01
+          toolchain: stable
           components: rustfmt, clippy
 
       - name: Install Tarpaulin

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: true
 
       - name: Install Tarpaulin
         run: cargo install cargo-tarpaulin  --locked
@@ -57,7 +59,7 @@ jobs:
         run: cargo tarpaulin --workspace --out Xml --out Html
 
       - name: Upload coverage reports
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: code-coverage-report
           path: |


### PR DESCRIPTION
This pull request introduces a new job to the CI workflow for generating Rust code coverage reports using Tarpaulin.

* Added a new `rust-coverage` job to `.github/workflows/ci.yml` to generate code coverage reports using Tarpaulin. This job includes steps for checking out the repository, installing the Rust toolchain, installing Tarpaulin, and running Tarpaulin to produce coverage reports in XML format.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Enhanced CI workflow by adding a code coverage job for Rust project
	- Integrated Tarpaulin to generate XML coverage reports for the entire workspace

<!-- end of auto-generated comment: release notes by coderabbit.ai -->