### PR TITLE
add coverage to pr

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,7 @@ jobs:
       # Pull Request 上のみコメントを投稿
       - name: Post coverage comment
         if: ${{ github.event_name == 'pull_request' }}
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           script: |
             const fs = require('fs');

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,11 @@ on:
   push:
   pull_request:
 
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
 jobs:
   lint:
     runs-on: ubuntu-latest
@@ -55,24 +60,31 @@ jobs:
       - name: Install Tarpaulin
         run: cargo install cargo-tarpaulin --locked
 
-      # Tarpaulinの出力を tee でファイルにも保存する
+      # Tarpaulinの出力を tee でファイルにも保存
       - name: Run Tarpaulin
-        run: cargo tarpaulin --workspace --out Xml --out Html | tee tarpaulin_output.txt
+        run: |
+          cargo tarpaulin \
+            --workspace \
+            --out Xml \
+            --out Html \
+            | tee tarpaulin_output.txt
 
-      # 標準出力からカバレッジ概要行を抜き出し、coverage_summary.txt に保存
-      # （Tarpaulinのバージョンや出力フォーマットによって grep パターンを調整）
+      # 標準出力から「coverage,」を含む行を抜き出しファイル保存
       - name: Extract coverage summary
         run: |
-          grep 'coverage,' tarpaulin_output.txt > coverage_summary.txt || echo "No coverage info found" > coverage_summary.txt
+          grep 'coverage,' tarpaulin_output.txt > coverage_summary.txt \
+            || echo "No coverage info found" > coverage_summary.txt
 
-      # Pull Request 上でのみコメントを投稿するように条件指定
+      # Pull Request 上のみコメントを投稿
       - name: Post coverage comment
         if: ${{ github.event_name == 'pull_request' }}
         uses: actions/github-script@v6
         with:
           script: |
             const fs = require('fs');
-            const coverageSummary = fs.readFileSync('coverage_summary.txt', 'utf8').trim();
+            const coverageSummary = fs
+              .readFileSync('coverage_summary.txt', 'utf8')
+              .trim();
 
             if (coverageSummary === "No coverage info found") {
               console.log("No coverage info found. Skip commenting.");
@@ -84,7 +96,11 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.issue.number,
-              body: `**Tarpaulin Coverage Report**\n\`\`\`\n${coverageSummary}\n\`\`\``
+              body:
+                "**Tarpaulin Coverage Report**\n" +
+                "```\n" +
+                coverageSummary +
+                "\n```"
             });
 
   docker:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,8 @@
----
 name: CI
 
 on:
   push:
+  pull_request:
 
 jobs:
   lint:
@@ -53,18 +53,39 @@ jobs:
           submodules: true
 
       - name: Install Tarpaulin
-        run: cargo install cargo-tarpaulin  --locked
+        run: cargo install cargo-tarpaulin --locked
 
+      # Tarpaulinの出力を tee でファイルにも保存する
       - name: Run Tarpaulin
-        run: cargo tarpaulin --workspace --out Xml --out Html
+        run: cargo tarpaulin --workspace --out Xml --out Html | tee tarpaulin_output.txt
 
-      - name: Upload coverage reports
-        uses: actions/upload-artifact@v4
+      # 標準出力からカバレッジ概要行を抜き出し、coverage_summary.txt に保存
+      # （Tarpaulinのバージョンや出力フォーマットによって grep パターンを調整）
+      - name: Extract coverage summary
+        run: |
+          grep 'coverage,' tarpaulin_output.txt > coverage_summary.txt || echo "No coverage info found" > coverage_summary.txt
+
+      # Pull Request 上でのみコメントを投稿するように条件指定
+      - name: Post coverage comment
+        if: ${{ github.event_name == 'pull_request' }}
+        uses: actions/github-script@v6
         with:
-          name: code-coverage-report
-          path: |
-            cobertura.xml
-            tarpaulin-report.html
+          script: |
+            const fs = require('fs');
+            const coverageSummary = fs.readFileSync('coverage_summary.txt', 'utf8').trim();
+
+            if (coverageSummary === "No coverage info found") {
+              console.log("No coverage info found. Skip commenting.");
+              return;
+            }
+
+            // Pull Requestにコメントを投稿
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: `**Tarpaulin Coverage Report**\n\`\`\`\n${coverageSummary}\n\`\`\``
+            });
 
   docker:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This pull request includes updates to the CI workflow configuration to enhance code coverage reporting and ensure comments are posted on pull requests. The most important changes include adding the `pull_request` trigger, saving Tarpaulin output to a file, extracting coverage summary, and posting a coverage comment on pull requests.

Enhancements to CI workflow:

* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL1-R5): Added `pull_request` trigger to ensure the workflow runs on pull requests as well as pushes.
* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR58-R88): Modified the `Run Tarpaulin` step to save output to `tarpaulin_output.txt` using `tee`.
* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR58-R88): Added a step to extract coverage summary from `tarpaulin_output.txt` and save it to `coverage_summary.txt`.
* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR58-R88): Added a step to post a coverage comment on pull requests using `actions/github-script@v6`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated GitHub Actions workflow to trigger on pull requests.
	- Enhanced CI process with improved coverage summary generation.
	- Added automated coverage comment posting for pull requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->