### PR TITLE
add windows constant

### DIFF
--- a/saba_core/src/constants.rs
+++ b/saba_core/src/constants.rs
@@ -1,6 +1,8 @@
 pub static WINDOW_WIDTH: i64 = 600;
 pub static WINDOW_HEIGHT: i64 = 400;
 pub static WINDOW_PADDING: i64 = 5;
+pub static WINDOW_INIT_X_POS: i64 = 30;
+pub static WINDOW_INIT_Y_POS: i64 = 50;
 
 pub static TITLE_BAR_HEIGHT: i64 = 24;
 pub static TOOLBAR_HEIGHT: i64 = 26;
@@ -12,3 +14,5 @@ pub static CONTENT_AREA_HEIGHT: i64 =
 pub static CHAR_WIDTH: i64 = 8;
 pub static CHAR_HEIGHT: i64 = 16;
 pub static CHAR_HEIGHT_WITH_PADDING: i64 = CHAR_HEIGHT + 4;
+
+pub static WHITE: u32 = 0xFFFFFF;


### PR DESCRIPTION
This pull request includes changes to the `saba_core/src/constants.rs` file to add new constants for window initialization and color.

The most important changes include:

* Added constants for initial window position:
  * `WINDOW_INIT_X_POS` set to 30
  * `WINDOW_INIT_Y_POS` set to 50

* Added a constant for the color white:
  * `WHITE` set to `0xFFFFFF`