### PR TITLE
add tool bar function

### DIFF
--- a/ui/wasabi/src/app.rs
+++ b/ui/wasabi/src/app.rs
@@ -1,13 +1,11 @@
 use crate::alloc::string::ToString;
 use alloc::rc::Rc;
 use core::cell::RefCell;
+use noli::error::Result as OsResult;
+use noli::window::StringSize;
 use noli::window::Window;
 use saba_core::browser::Browser;
-use saba_core::constants::WHITE;
-use saba_core::constants::WINDOW_HEIGHT;
-use saba_core::constants::WINDOW_INIT_X_POS;
-use saba_core::constants::WINDOW_INIT_Y_POS;
-use saba_core::constants::WINDOW_WIDTH;
+use saba_core::constants::*;
 
 #[derive(Debug)]
 #[allow(dead_code)]
@@ -16,7 +14,41 @@ pub struct WasabiUI {
     window: Window,
 }
 
+#[allow(dead_code)]
 impl WasabiUI {
+    fn setup_toolbar(&mut self) -> OsResult<()> {
+        self.window
+            .fill_rect(LIGHT_GRAY, 0, 0, WINDOW_WIDTH, TOOLBAR_HEIGHT)?;
+
+        self.window.draw_line(
+            DARK_GRAY,
+            0,
+            TITLE_BAR_HEIGHT + 1,
+            WINDOW_WIDTH - 1,
+            TOOLBAR_HEIGHT + 1,
+        )?;
+
+        self.window.draw_string(
+            BLACK,
+            5,
+            5,
+            "Address:",
+            StringSize::Medium,
+            /*underline=*/ false,
+        )?;
+
+        self.window
+            .fill_rect(WHITE, 70, 2, WINDOW_WIDTH - 74, 2 + ADDRESS_BAR_HEIGHT)?;
+
+        self.window.draw_line(GRAY, 70, 2, WINDOW_WIDTH - 4, 2)?;
+        self.window
+            .draw_line(GRAY, 70, 2, 70, 2 + ADDRESS_BAR_HEIGHT)?;
+        self.window.draw_line(BLACK, 71, 3, WINDOW_WIDTH - 5, 3)?;
+
+        self.window
+            .draw_line(GRAY, 71, 3, 71, 1 + ADDRESS_BAR_HEIGHT)?;
+        Ok(())
+    }
     pub fn new(browser: Rc<RefCell<Browser>>) -> Self {
         Self {
             browser,


### PR DESCRIPTION
This pull request includes changes to the `ui/wasabi/src/app.rs` file to improve the organization of imports and add a new method for setting up the toolbar in the `WasabiUI` struct.

### Improvements to imports:

* Consolidated multiple import statements from `saba_core::constants` into a single statement using a wildcard.

### New functionality:

* Added a new method `setup_toolbar` to the `WasabiUI` struct to initialize and draw the toolbar, including filling rectangles and drawing lines and strings. This method uses the `OsResult` type for error handling.