### PR TITLE
add ui to cargo

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2021"
 
 [features]
 default = ["wasabi"]
-wasabi = ["dep:net_wasabi", "dep:noli"]
+wasabi = ["dep:net_wasabi", "dep:ui_wasabi", "dep:noli"]
 
 [[bin]]
 name = "saba"
@@ -20,6 +20,7 @@ required-features = ["wasabi"]
 [dependencies]
 saba_core = { path = "./saba_core" }
 net_wasabi = { path = "./net/wasabi", optional = true }
+ui_wasabi = { path = "./ui/wasabi", optional = true }
 noli = { git = "https://github.com/hikalium/wasabi.git", branch = "for_saba", optional = true }
 cargo-husky = "1.5.0"
 

--- a/ui/wasabi/Cargo.toml
+++ b/ui/wasabi/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "ui-wasabi"
+name = "ui_wasabi"
 version = "0.1.0"
 edition = "2024"
 


### PR DESCRIPTION
This pull request includes changes to the `Cargo.toml` files to update feature dependencies and rename a package. The most important changes are:

Feature dependencies update:

* [`Cargo.toml`](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L13-R13): Added `dep:ui_wasabi` to the `wasabi` feature dependencies.
* [`Cargo.toml`](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542R23): Added `ui_wasabi` as an optional dependency.

Package renaming:

* [`ui/wasabi/Cargo.toml`](diffhunk://#diff-5b002edad458a52c0883a5fb9aa99de8cc626154e491d0f64f791ef4ce2214eeL2-R2): Renamed the package from `ui-wasabi` to `ui_wasabi`.