### PR TITLE
add ui to main

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -2,33 +2,23 @@
 #![cfg_attr(not(target_os = "linux"), no_main)]
 
 extern crate alloc;
-use crate::alloc::string::ToString;
+
+use alloc::rc::Rc;
+use core::cell::RefCell;
 use noli::*;
 use saba_core::browser::Browser;
-use saba_core::http::HttpResponse;
-
-static TEST_HTTP_RESPONSE: &str = r#"HTTP/1.1 200 OK
-Data xx xx xx
-<html>
-    <head></head>
-    <body>
-        <h1 id=title>H1 Title</h1>
-        <h2 class="class">H2 title</h2>
-        <p>Test text.</p>
-        <p>
-            <a href="example.com">Link1</a>
-            <a href="example">Link2</a>
-        </p>
-    </body>
-    </html>
-    "#;
+use ui_wasabi::app::WasabiUI;
 
 fn main() {
     let browser = Browser::new();
-    let response =
-        HttpResponse::new(TEST_HTTP_RESPONSE.to_string()).expect("failed to parse http response");
-    let page = browser.borrow().current_page();
-    page.borrow_mut().receive_response(response);
+
+    let ui = Rc::new(RefCell::new(WasabiUI::new(browser)));
+    match ui.borrow_mut().start() {
+        Ok(_) => {}
+        Err(e) => {
+            println!("browser fails to start: {:?}", e);
+        }
+    };
 }
 
 entry_point!(main);


### PR DESCRIPTION
This pull request includes significant changes to the `src/main.rs` file to refactor the code and improve the user interface handling. The most important changes include the removal of the static HTTP response, the introduction of `WasabiUI`, and the use of `Rc` and `RefCell` for better memory management.

Refactoring and improvements:

* Removed the static `TEST_HTTP_RESPONSE` and the associated `HttpResponse` handling.
* Introduced `WasabiUI` from `ui_wasabi::app` to manage the user interface.
* Utilized `Rc` and `RefCell` from `alloc` and `core::cell` respectively for reference counting and interior mutability.

Error handling:

* Added error handling for the `WasabiUI::start` method to print an error message if the browser fails to start.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new user interface with enhanced initialization and error handling
- **Refactor**
	- Simplified main application startup process
	- Improved UI management using advanced Rust reference techniques

<!-- end of auto-generated comment: release notes by coderabbit.ai -->