### PR TITLE
Bugfix/start qemu

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,9 +22,14 @@ saba_core = { path = "./saba_core" }
 net_wasabi = { path = "./net/wasabi", optional = true }
 ui_wasabi = { path = "./ui/wasabi", optional = true }
 noli = { git = "https://github.com/hikalium/wasabi.git", branch = "for_saba", optional = true }
-cargo-husky = "1.5.0"
+# cargo-husky = "1.5.0"
 
-[dev-dependencies.cargo-husky]
-version = "1"
-default-features = false
-features = ["user-hooks"]
+# [dev-dependencies.cargo-husky]
+# version = "1"
+# default-features = false
+# features = ["user-hooks"]
+
+[dev-dependencies]
+cargo-husky = { version = "1.5.0", default-features = false, features = [
+  "user-hooks",
+] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,12 +22,6 @@ saba_core = { path = "./saba_core" }
 net_wasabi = { path = "./net/wasabi", optional = true }
 ui_wasabi = { path = "./ui/wasabi", optional = true }
 noli = { git = "https://github.com/hikalium/wasabi.git", branch = "for_saba", optional = true }
-# cargo-husky = "1.5.0"
-
-# [dev-dependencies.cargo-husky]
-# version = "1"
-# default-features = false
-# features = ["user-hooks"]
 
 [dev-dependencies]
 cargo-husky = { version = "1.5.0", default-features = false, features = [

--- a/README.md
+++ b/README.md
@@ -134,6 +134,17 @@ task logs
 4. Push to the branch
 5. Create a Pull Request
 
+## Note
+
+Start QEMU GUI you need to change Makefile under build/wasabi/Makefile.
+
+```build/wasabi/Makefile
+ifndef DISPLAY
+# QEMU_ARGS+= -vnc 0.0.0.0:$(PORT_OFFSET_VNC),password=on
+QEMU_ARGS+= -display cocoa
+endif
+```
+
 ## License
 
 This project is licensed under the MIT License. See the [LICENSE](LICENSE) file for details.


### PR DESCRIPTION
This pull request includes updates to the `Cargo.toml` file and additional instructions in the `README.md` file. The most important changes are:

Dependency management updates:

* [`Cargo.toml`](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L25-R29): Changed the format of the `cargo-husky` dependency to be under `[dev-dependencies]` with specific features enabled.

Documentation updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R137-R147): Added a note with instructions on how to start the QEMU GUI, including modifications to the `Makefile` under `build/wasabi/Makefile`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated README with a new section providing instructions for starting QEMU GUI
	- Added guidance for configuring QEMU display settings

- **Chores**
	- Restructured `cargo-husky` dev-dependency configuration in `Cargo.toml`
	- Enhanced dependency declaration with more explicit settings

<!-- end of auto-generated comment: release notes by coderabbit.ai -->