### PR TITLE
add handle input mode

### DIFF
--- a/ui/wasabi/src/app.rs
+++ b/ui/wasabi/src/app.rs
@@ -1,10 +1,12 @@
 use crate::alloc::string::ToString;
 use alloc::format;
 use alloc::rc::Rc;
+use alloc::string::String;
 use core::cell::RefCell;
 use noli::error::Result as OsResult;
 // use noli::prelude::SystemApi;
 // use noli::println;
+use noli::rect::Rect;
 // use noli::sys::api::MouseEvent;
 // use noli::sys::wasabi::Api;
 use noli::window::StringSize;
@@ -24,19 +26,78 @@ use saba_core::constants::WINDOW_INIT_Y_POS;
 use saba_core::constants::WINDOW_WIDTH;
 use saba_core::error::Error;
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[allow(dead_code)]
+enum InputMode {
+    Normal,
+    Editing,
+}
+
 #[derive(Debug)]
 #[allow(dead_code)]
 pub struct WasabiUI {
     browser: Rc<RefCell<Browser>>,
+    input_url: String,
+    input_mode: InputMode,
     window: Window,
 }
 
 #[allow(dead_code)]
 impl WasabiUI {
     fn handle_key_input(&mut self) -> Result<(), Error> {
-        // if let Some(c) = Api::read_key() {
-        //     println!("input text: {:?}", c);
-        // }
+        match self.input_mode {
+            InputMode::Normal => {
+                // let _ = Api::read_key();
+            }
+            InputMode::Editing => {
+                // if let Some(c) = Api::read_key() {
+                //     if c == 0x7F as char || c == 0x08 as char {
+                //         self.input_url.pop();
+                //     } else {
+                //         self.input_url.push(c);
+                //     }
+                // }
+            }
+        }
+        Ok(())
+    }
+
+    fn update_address_bar(&mut self) -> Result<(), Error> {
+        if self
+            .window
+            .fill_rect(WHITE, 72, 4, WINDOW_WIDTH - 76, ADDRESS_BAR_HEIGHT - 2)
+            .is_err()
+        {
+            return Err(Error::InvalidUI(
+                "failed to clear an address bar".to_string(),
+            ));
+        }
+        if self
+            .window
+            .draw_string(
+                BLACK,
+                74,
+                6,
+                &self.input_url,
+                StringSize::Medium,
+                /*underline=*/ false,
+            )
+            .is_err()
+        {
+            return Err(Error::InvalidUI(
+                "failed to clear an address bar".to_string(),
+            ));
+        }
+
+        self.window.flush_area(
+            Rect::new(
+                WINDOW_INIT_X_POS,
+                WINDOW_INIT_Y_POS,
+                WINDOW_WIDTH,
+                TOOLBAR_HEIGHT,
+            )
+            .expect("failed to create a rect for the address bar"),
+        );
         Ok(())
     }
     fn handle_mouse_input(&mut self) -> Result<(), Error> {
@@ -113,6 +174,8 @@ impl WasabiUI {
     pub fn new(browser: Rc<RefCell<Browser>>) -> Self {
         Self {
             browser,
+            input_url: String::new(),
+            input_mode: InputMode::Normal,
             window: Window::new(
                 "saba".to_string(),
                 WHITE,


### PR DESCRIPTION
This pull request includes several changes to the `ui/wasabi/src/app.rs` file to enhance the WasabiUI functionality. The most important changes include the addition of new enum `InputMode`, handling key input based on the input mode, and updating the address bar.

Enhancements to WasabiUI:

* Added `InputMode` enum to manage different input states (`Normal` and `Editing`).
* Modified the `WasabiUI` struct to include `input_url` and `input_mode` fields. [[1]](diffhunk://#diff-489bfb23ff21e0ec344f19391502d6943c60c70a4d6f13ef9fd6ec376712c31fR29-R100) [[2]](diffhunk://#diff-489bfb23ff21e0ec344f19391502d6943c60c70a4d6f13ef9fd6ec376712c31fR177-R178)
* Updated `handle_key_input` method to handle key inputs differently based on the current `input_mode`.
* Implemented `update_address_bar` method to clear and redraw the address bar with the current input URL.

Code organization:

* Added missing `alloc::string::String` and `noli::rect::Rect` imports to the `ui/wasabi/src/app.rs` file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced input handling modes for the UI
  - Added an address bar with URL management functionality

- **Improvements**
  - Enhanced key input handling with conditional mode-based processing
<!-- end of auto-generated comment: release notes by coderabbit.ai -->