### PR TITLE
add clear address bar

### DIFF
--- a/ui/wasabi/src/app.rs
+++ b/ui/wasabi/src/app.rs
@@ -100,6 +100,28 @@ impl WasabiUI {
         );
         Ok(())
     }
+    fn clear_address_bar(&mut self) -> Result<(), Error> {
+        if self
+            .window
+            .fill_rect(WHITE, 72, 4, WINDOW_WIDTH - 76, ADDRESS_BAR_HEIGHT - 2)
+            .is_err()
+        {
+            return Err(Error::InvalidUI(
+                "failed to clear an address bar".to_string(),
+            ));
+        }
+
+        self.window.flush_area(
+            Rect::new(
+                WINDOW_INIT_X_POS,
+                WINDOW_INIT_Y_POS + TITLE_BAR_HEIGHT,
+                WINDOW_WIDTH,
+                TOOLBAR_HEIGHT,
+            )
+            .expect("failed to create a rect for the address bar"),
+        );
+        Ok(())
+    }
     fn handle_mouse_input(&mut self) -> Result<(), Error> {
         // if let Some(MouseEvent {
         //     button: button,


### PR DESCRIPTION
This pull request introduces a new method to the `WasabiUI` implementation in the `ui/wasabi/src/app.rs` file. The new method, `clear_address_bar`, aims to clear the address bar and handle potential errors during the process.

### New Method Addition:

* [`ui/wasabi/src/app.rs`](diffhunk://#diff-489bfb23ff21e0ec344f19391502d6943c60c70a4d6f13ef9fd6ec376712c31fR103-R124): Added the `clear_address_bar` method to the `WasabiUI` implementation. This method clears the address bar by filling a rectangular area with white color and flushing the area to update the UI. It handles errors by returning an `Error::InvalidUI` if the fill operation fails.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added a method to clear the address bar in the user interface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->