### PR TITLE
Feature/add update address bar in handle key input

### DIFF
--- a/ui/wasabi/src/app.rs
+++ b/ui/wasabi/src/app.rs
@@ -52,9 +52,11 @@ impl WasabiUI {
             InputMode::Editing => {
                 // if let Some(c) = Api::read_key() {
                 //     if c == 0x7F as char || c == 0x08 as char {
-                //         self.input_url.pop();
+                self.input_url.pop();
+                self.update_address_bar()?;
                 //     } else {
-                //         self.input_url.push(c);
+                self.input_url.push(c);
+                self.update_address_bar()?;
                 //     }
                 // }
             }

--- a/ui/wasabi/src/app.rs
+++ b/ui/wasabi/src/app.rs
@@ -55,7 +55,7 @@ impl WasabiUI {
                 self.input_url.pop();
                 self.update_address_bar()?;
                 //     } else {
-                self.input_url.push(c);
+                // self.input_url.push(c);
                 self.update_address_bar()?;
                 //     }
                 // }


### PR DESCRIPTION
This pull request includes a change to the `WasabiUI` implementation in the `ui/wasabi/src/app.rs` file. The change involves updating the address bar whenever the input URL is modified.

* [`ui/wasabi/src/app.rs`](diffhunk://#diff-489bfb23ff21e0ec344f19391502d6943c60c70a4d6f13ef9fd6ec376712c31fL55-R59): Added calls to `self.update_address_bar()?` after modifying the `input_url` to ensure the address bar reflects the current state of the input URL.