### PR TITLE
add change input mode

### DIFF
--- a/ui/wasabi/src/app.rs
+++ b/ui/wasabi/src/app.rs
@@ -27,14 +27,12 @@ use saba_core::constants::WINDOW_WIDTH;
 use saba_core::error::Error;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-#[allow(dead_code)]
 enum InputMode {
     Normal,
     Editing,
 }
 
 #[derive(Debug)]
-#[allow(dead_code)]
 pub struct WasabiUI {
     browser: Rc<RefCell<Browser>>,
     input_url: String,
@@ -130,9 +128,31 @@ impl WasabiUI {
             position,
         }) = Api::get_mouse_cursor_info()
         {
-            println!("mouse position {:?}", position);
             if button.l() || button.c() || button.r() {
                 println!("mouse clicked {:?}", button);
+                let relative_pos = (
+                    position.x - WINDOW_INIT_X_POS,
+                    position.y - WINDOW_INIT_Y_POS,
+                );
+
+                if relative_pos.0 >= 0
+                    || relative_pos.0 > WINDOW_WIDTH
+                    || relative_pos.1 < 0
+                    || relative_pos.1 > TOOLBAR_HEIGHT
+                {
+                    println!("button clicked OUTSIDE the window: {button:?} {position:?}");
+                    return Ok(());
+                }
+                if relative_pos.1 < TOOLBAR_HEIGHT + TITLE_BAR_HEIGHT
+                    && relative_pos.1 >= TITLE_BAR_HEIGHT
+                {
+                    self.clear_address_bar()?;
+                    self.input_url = String::new();
+                    self.input_mode = InputMode::Editing;
+                    println!("button clicked in toolbar: {button:?} {position:?}");
+                    return Ok(());
+                }
+                self.inoput_mode = InputMode::Normal;
             }
         }
         Ok(())


### PR DESCRIPTION
This pull request includes changes to the `ui/wasabi/src/app.rs` file to improve the handling of mouse click events and remove unused code. The most important changes include adding logic to handle mouse clicks based on their position relative to the window and toolbar, and removing `#[allow(dead_code)]` attributes from unused code.

Improvements to mouse click handling:

* Added logic to calculate the relative position of mouse clicks and handle clicks outside the window and within the toolbar. This includes clearing the address bar and changing the input mode to `Editing` when clicks are detected in the toolbar. (`ui/wasabi/src/app.rs`)

Code cleanup:

* Removed `#[allow(dead_code)]` attributes from the `InputMode` enum and `WasabiUI` struct to clean up the codebase. (`ui/wasabi/src/app.rs`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed a potential runtime error related to mouse input handling
  - Improved address bar interaction by enabling direct editing when toolbar is clicked

- **User Experience**
  - Added boundary checks for mouse clicks within the application window
  - Enhanced toolbar interaction for more intuitive address bar management
<!-- end of auto-generated comment: release notes by coderabbit.ai -->