### PR TITLE
fix qemu is not started

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,14 @@ QEMU_ARGS+= -display cocoa
 endif
 ```
 
+If you rebuild entire wasabi then you need to un comment the line.
+
+```browser/Cargo.toml
+[features]
+default = ["wasabi"]
+wasabi = ["dep:net_wasabi", "dep:ui_wasabi", "dep:noli"]
+```
+
 ## License
 
 This project is licensed under the MIT License. See the [LICENSE](LICENSE) file for details.

--- a/src/main.rs
+++ b/src/main.rs
@@ -78,7 +78,7 @@ fn main() {
     let browser = Browser::new();
 
     let ui = Rc::new(RefCell::new(WasabiUI::new(browser)));
-    match ui.borrow_mut().start() {
+    match ui.borrow_mut().start(handle_url) {
         Ok(_) => {}
         Err(e) => {
             println!("browser fails to start: {:?}", e);

--- a/ui/wasabi/src/cursor.rs
+++ b/ui/wasabi/src/cursor.rs
@@ -1,3 +1,4 @@
+#[allow(unused_imports)]
 use noli::bitmap::{self, bitmap_draw_rect};
 use noli::rect::Rect;
 use noli::sheet::Sheet;


### PR DESCRIPTION
This pull request includes several changes to improve the functionality and maintainability of the Wasabi UI project. The most important changes involve modifying function signatures to handle URL responses, adding comments for clarity, and ensuring unused imports are allowed without warnings.

### Functionality Enhancements:
* [`src/main.rs`](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcL81-R81): Updated the `main` function to pass `handle_url` to `ui.borrow_mut().start()` to handle URL responses.
* [`ui/wasabi/src/app.rs`](diffhunk://#diff-489bfb23ff21e0ec344f19391502d6943c60c70a4d6f13ef9fd6ec376712c31fL80-R82): Modified `start`, `run_app`, and `start_navigation` methods to include `handle_url` with a return type of `Result<HttpResponse, Error>`. [[1]](diffhunk://#diff-489bfb23ff21e0ec344f19391502d6943c60c70a4d6f13ef9fd6ec376712c31fL80-R82) [[2]](diffhunk://#diff-489bfb23ff21e0ec344f19391502d6943c60c70a4d6f13ef9fd6ec376712c31fL249-R270)

### Code Clarity and Maintenance:
* [`ui/wasabi/src/app.rs`](diffhunk://#diff-489bfb23ff21e0ec344f19391502d6943c60c70a4d6f13ef9fd6ec376712c31fL105-R110): Added comments explaining the use of `RefCell::borrow()` for accessing browser references without using the `Borrow` trait.
* [`ui/wasabi/src/app.rs`](diffhunk://#diff-489bfb23ff21e0ec344f19391502d6943c60c70a4d6f13ef9fd6ec376712c31fL218-R226): Updated print statements to use indexed formatting for better readability. [[1]](diffhunk://#diff-489bfb23ff21e0ec344f19391502d6943c60c70a4d6f13ef9fd6ec376712c31fL218-R226) [[2]](diffhunk://#diff-489bfb23ff21e0ec344f19391502d6943c60c70a4d6f13ef9fd6ec376712c31fL228-R237)
* `ui/wasabi/src/app.rs`, `ui/wasabi/src/cursor.rs`: Added `#[allow(unused_imports)]` to suppress warnings for unused imports. [[1]](diffhunk://#diff-489bfb23ff21e0ec344f19391502d6943c60c70a4d6f13ef9fd6ec376712c31fR6-R8) [[2]](diffhunk://#diff-4a4efa77c0bcc7b87bb457ece8972c8cb1267092f422f7ea565745b16b2aff6cR1)

### Documentation:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R149-R156): Added instructions to uncomment specific lines in `browser/Cargo.toml` when rebuilding Wasabi entirely.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **Documentation**
  - Updated README with instructions for rebuilding Wasabi component
  - Added guidance for uncommenting specific line in `Cargo.toml`

- **New Features**
  - Introduced new `Cursor` struct with graphical representation
  - Enhanced URL handling capabilities in UI components

- **Improvements**
  - Refined error handling in UI navigation methods
  - Updated method signatures to support more robust URL processing

These changes improve project documentation, add cursor management functionality, and enhance overall UI interaction mechanisms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->