### PR TITLE
add convert font size

### DIFF
--- a/ui/wasabi/src/app.rs
+++ b/ui/wasabi/src/app.rs
@@ -32,6 +32,7 @@ use saba_core::constants::WINDOW_INIT_Y_POS;
 use saba_core::constants::WINDOW_WIDTH;
 use saba_core::error::Error;
 use saba_core::http::HttpResponse;
+use saba_core::renderer::layout::computed_style::FontSize;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum InputMode {
@@ -322,5 +323,13 @@ impl WasabiUI {
         self.window
             .draw_line(GRAY, 71, 3, 71, 1 + ADDRESS_BAR_HEIGHT)?;
         Ok(())
+    }
+}
+
+fn convert_font_size(size: FontSize) -> StringSize {
+    match size {
+        FontSize::Medium => StringSize::Medium,
+        FontSize::XLarge => StringSize::Large,
+        FontSize::XXLarge => StringSize::XLarge,
     }
 }


### PR DESCRIPTION
This pull request introduces a new function to convert font sizes and adds a necessary import to support this function in the `ui/wasabi/src/app.rs` file.

Codebase enhancements:

* [`ui/wasabi/src/app.rs`](diffhunk://#diff-489bfb23ff21e0ec344f19391502d6943c60c70a4d6f13ef9fd6ec376712c31fR35): Added import for `FontSize` from `saba_core::renderer::layout::computed_style` to support font size conversion.
* [`ui/wasabi/src/app.rs`](diffhunk://#diff-489bfb23ff21e0ec344f19391502d6943c60c70a4d6f13ef9fd6ec376712c31fR328-R335): Implemented `convert_font_size` function to map `FontSize` variants to corresponding `StringSize` values.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added a utility function to convert font sizes between different style systems.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->