### PR TITLE
Feature/add jslexer

### DIFF
--- a/saba_core/src/renderer/js/token.rs
+++ b/saba_core/src/renderer/js/token.rs
@@ -23,6 +23,7 @@ pub struct JsLexer {
     input: Vec<char>,
 }
 
+#[allow(clippy::needless_return)]
 impl JsLexer {
     pub fn new(js: String) -> Self {
         Self {

--- a/saba_core/src/renderer/js/token.rs
+++ b/saba_core/src/renderer/js/token.rs
@@ -1,5 +1,51 @@
+use alloc::string::String;
+use alloc::vec::Vec;
+
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub enum Token {
     Punctuator(char),
     Number(u64),
+}
+
+pub struct JsLexer {
+    pos: usize,
+    input: Vec<char>,
+}
+
+impl JsLexer {
+    pub fn new(js: String) -> Self {
+        Self {
+            pos: 0,
+            input: js.chars().collect(),
+        }
+    }
+}
+
+impl Iterator for JsLexer {
+    type Item = Token;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        while self.pos < self.input.len() {
+            let c = self.input[self.pos];
+            match c {
+                '0'..='9' => {
+                    let mut num = String::new();
+                    while self.pos < self.input.len() && self.input[self.pos].is_digit(10) {
+                        num.push(self.input[self.pos]);
+                        self.pos += 1;
+                    }
+                    return Some(Token::Number(num.parse().unwrap()));
+                }
+                '+' | '-' | '*' | '/' | '%' | '(' | ')' | '{' | '}' | ';' | ',' => {
+                    self.pos += 1;
+                    return Some(Token::Punctuator(c));
+                }
+                _ => {
+                    self.pos += 1;
+                }
+            }
+        }
+
+        None
+    }
 }

--- a/saba_core/src/renderer/js/token.rs
+++ b/saba_core/src/renderer/js/token.rs
@@ -1,10 +1,21 @@
 use alloc::string::String;
+use alloc::string::ToString;
 use alloc::vec::Vec;
 
-#[derive(Debug, Clone, Eq, PartialEq)]
+static RESERVED_WORDS: [&str; 3] = ["var", "function", "return"];
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Token {
+    /// https://262.ecma-international.org/#sec-punctuators
     Punctuator(char),
+    /// https://262.ecma-international.org/#sec-literals-numeric-literals
     Number(u64),
+    /// https://262.ecma-international.org/#sec-identifier-names
+    Identifier(String),
+    /// https://262.ecma-international.org/#sec-keywords-and-reserved-words
+    Keyword(String),
+    /// https://262.ecma-international.org/#sec-literals-string-literals
+    StringLiteral(String),
 }
 
 pub struct JsLexer {
@@ -19,33 +30,255 @@ impl JsLexer {
             input: js.chars().collect(),
         }
     }
+
+    fn contains(&self, keyword: &str) -> bool {
+        for i in 0..keyword.len() {
+            if keyword
+                .chars()
+                .nth(i)
+                .expect("failed to access to i-th char")
+                != self.input[self.pos + i]
+            {
+                return false;
+            }
+        }
+
+        true
+    }
+
+    fn check_reserved_word(&self) -> Option<String> {
+        for word in RESERVED_WORDS {
+            if self.contains(word) {
+                return Some(word.to_string());
+            }
+        }
+
+        None
+    }
+
+    fn consume_identifier(&mut self) -> String {
+        let mut result = String::new();
+
+        loop {
+            if self.pos >= self.input.len() {
+                return result;
+            }
+
+            if self.input[self.pos].is_ascii_alphanumeric()
+                || self.input[self.pos] == '_'
+                || self.input[self.pos] == '$'
+            {
+                result.push(self.input[self.pos]);
+                self.pos += 1;
+            } else {
+                return result;
+            }
+        }
+    }
+
+    fn consume_string(&mut self) -> String {
+        let mut result = String::new();
+        self.pos += 1;
+
+        loop {
+            if self.pos >= self.input.len() {
+                return result;
+            }
+
+            if self.input[self.pos] == '"' {
+                self.pos += 1;
+                return result;
+            }
+
+            result.push(self.input[self.pos]);
+            self.pos += 1;
+        }
+    }
+
+    fn consume_number(&mut self) -> u64 {
+        let mut num = 0;
+
+        loop {
+            if self.pos >= self.input.len() {
+                return num;
+            }
+
+            let c = self.input[self.pos];
+
+            match c {
+                '0'..='9' => {
+                    num = num * 10 + (c.to_digit(10).unwrap() as u64);
+                    self.pos += 1;
+                }
+                _ => break,
+            }
+        }
+
+        return num;
+    }
 }
 
 impl Iterator for JsLexer {
     type Item = Token;
 
     fn next(&mut self) -> Option<Self::Item> {
-        while self.pos < self.input.len() {
-            let c = self.input[self.pos];
-            match c {
-                '0'..='9' => {
-                    let mut num = String::new();
-                    while self.pos < self.input.len() && self.input[self.pos].is_digit(10) {
-                        num.push(self.input[self.pos]);
-                        self.pos += 1;
-                    }
-                    return Some(Token::Number(num.parse().unwrap()));
-                }
-                '+' | '-' | '*' | '/' | '%' | '(' | ')' | '{' | '}' | ';' | ',' => {
-                    self.pos += 1;
-                    return Some(Token::Punctuator(c));
-                }
-                _ => {
-                    self.pos += 1;
-                }
+        if self.pos >= self.input.len() {
+            return None;
+        }
+
+        // ホワイトスペースまたは改行文字が続く限り、次の位置に進める
+        while self.input[self.pos] == ' ' || self.input[self.pos] == '\n' {
+            self.pos += 1;
+
+            if self.pos >= self.input.len() {
+                return None;
             }
         }
 
-        None
+        // 予約語が現れたら、Keywordトークンを返す
+        if let Some(keyword) = self.check_reserved_word() {
+            self.pos += keyword.len();
+            let token = Some(Token::Keyword(keyword));
+            return token;
+        }
+
+        let c = self.input[self.pos];
+
+        let token = match c {
+            '+' | '-' | ';' | '=' | '(' | ')' | '{' | '}' | ',' | '.' => {
+                let t = Token::Punctuator(c);
+                self.pos += 1;
+                t
+            }
+            '0'..='9' => Token::Number(self.consume_number()),
+            'a'..='z' | 'A'..='Z' | '_' | '$' => Token::Identifier(self.consume_identifier()),
+            '"' => Token::StringLiteral(self.consume_string()),
+            _ => unimplemented!("char {:?} is not supported yet", c),
+        };
+
+        Some(token)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_empty() {
+        let input = "".to_string();
+        let mut lexer = JsLexer::new(input).peekable();
+        assert!(lexer.peek().is_none());
+    }
+
+    #[test]
+    fn test_num() {
+        let input = "42".to_string();
+        let mut lexer = JsLexer::new(input).peekable();
+        let expected = [Token::Number(42)].to_vec();
+        let mut i = 0;
+        while lexer.peek().is_some() {
+            assert_eq!(Some(expected[i].clone()), lexer.next());
+            i += 1;
+        }
+        assert!(lexer.peek().is_none());
+    }
+
+    #[test]
+    fn test_add_nums() {
+        let input = "1 + 2".to_string();
+        let mut lexer = JsLexer::new(input).peekable();
+        let expected = [Token::Number(1), Token::Punctuator('+'), Token::Number(2)].to_vec();
+        let mut i = 0;
+        while lexer.peek().is_some() {
+            assert_eq!(Some(expected[i].clone()), lexer.next());
+            i += 1;
+        }
+        assert!(lexer.peek().is_none());
+    }
+
+    #[test]
+    fn test_assign_variable() {
+        let input = "var foo=\"bar\";".to_string();
+        let mut lexer = JsLexer::new(input).peekable();
+        let expected = [
+            Token::Keyword("var".to_string()),
+            Token::Identifier("foo".to_string()),
+            Token::Punctuator('='),
+            Token::StringLiteral("bar".to_string()),
+            Token::Punctuator(';'),
+        ]
+        .to_vec();
+        let mut i = 0;
+        while lexer.peek().is_some() {
+            assert_eq!(Some(expected[i].clone()), lexer.next());
+            i += 1;
+        }
+        assert!(lexer.peek().is_none());
+    }
+
+    #[test]
+    fn test_add_variable_and_num() {
+        let input = "var foo=42; var result=foo+1;".to_string();
+        let mut lexer = JsLexer::new(input).peekable();
+        let expected = [
+            Token::Keyword("var".to_string()),
+            Token::Identifier("foo".to_string()),
+            Token::Punctuator('='),
+            Token::Number(42),
+            Token::Punctuator(';'),
+            Token::Keyword("var".to_string()),
+            Token::Identifier("result".to_string()),
+            Token::Punctuator('='),
+            Token::Identifier("foo".to_string()),
+            Token::Punctuator('+'),
+            Token::Number(1),
+            Token::Punctuator(';'),
+        ]
+        .to_vec();
+        let mut i = 0;
+        while lexer.peek().is_some() {
+            assert_eq!(Some(expected[i].clone()), lexer.next());
+            i += 1;
+        }
+        assert!(lexer.peek().is_none());
+    }
+
+    #[test]
+    fn test_add_local_variable_and_num() {
+        let input = "function foo() { var a=42; return a; } var result = foo() + 1;".to_string();
+        let mut lexer = JsLexer::new(input).peekable();
+        let expected = [
+            Token::Keyword("function".to_string()),
+            Token::Identifier("foo".to_string()),
+            Token::Punctuator('('),
+            Token::Punctuator(')'),
+            Token::Punctuator('{'),
+            Token::Keyword("var".to_string()),
+            Token::Identifier("a".to_string()),
+            Token::Punctuator('='),
+            Token::Number(42),
+            Token::Punctuator(';'),
+            Token::Keyword("return".to_string()),
+            Token::Identifier("a".to_string()),
+            Token::Punctuator(';'),
+            Token::Punctuator('}'),
+            Token::Keyword("var".to_string()),
+            Token::Identifier("result".to_string()),
+            Token::Punctuator('='),
+            Token::Identifier("foo".to_string()),
+            Token::Punctuator('('),
+            Token::Punctuator(')'),
+            Token::Punctuator('+'),
+            Token::Number(1),
+            Token::Punctuator(';'),
+        ]
+        .to_vec();
+        let mut i = 0;
+        while lexer.peek().is_some() {
+            assert_eq!(Some(expected[i].clone()), lexer.next());
+            i += 1;
+        }
+        assert!(lexer.peek().is_none());
     }
 }


### PR DESCRIPTION
This pull request introduces significant enhancements to the JavaScript lexer implementation in the `saba_core/src/renderer/js/token.rs` file. The primary changes include defining a new `Token` enum, implementing a `JsLexer` struct with various token consumption methods, and adding comprehensive unit tests to ensure the lexer functions correctly.

Key changes include:

### Lexer Implementation:

* Introduced a `Token` enum to represent different types of tokens, including punctuators, numbers, identifiers, keywords, and string literals.
* Implemented the `JsLexer` struct with methods to tokenize JavaScript code, such as `consume_identifier`, `consume_string`, and `consume_number`.
* Added a `RESERVED_WORDS` static array to store JavaScript reserved words and a method `check_reserved_word` to identify them.

### Unit Testing:

* Added multiple unit tests to validate the lexer functionality, including tests for empty input, numeric literals, addition expressions, variable assignments, and function definitions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new JavaScript lexer for tokenizing JavaScript code
	- Added support for parsing identifiers, keywords, string literals, and numeric tokens
	- Implemented token generation with reserved word recognition

- **Tests**
	- Added comprehensive test cases to validate lexer functionality
<!-- end of auto-generated comment: release notes by coderabbit.ai -->